### PR TITLE
rs - Add HelpRequest Form component with tests

### DIFF
--- a/frontend/src/fixtures/helpRequestFixtures.js
+++ b/frontend/src/fixtures/helpRequestFixtures.js
@@ -1,0 +1,42 @@
+const helpRequestFixtures = {
+  oneHelpRequest: {
+    id: 1,
+    requesterEmail: "cgaucho@ucsb.edu",
+    teamId: "s22-5pm-3",
+    tableOrBreakoutRoom: "7",
+    requestTime: "2022-04-20T17:35:00",
+    explanation: "Need help with Swagger-ui",
+    solved: false,
+  },
+  threeHelpRequests: [
+    {
+      id: 1,
+      requesterEmail: "cgaucho@ucsb.edu",
+      teamId: "s22-5pm-3",
+      tableOrBreakoutRoom: "7",
+      requestTime: "2022-04-20T17:35:00",
+      explanation: "Need help with Swagger-ui",
+      solved: false,
+    },
+    {
+      id: 2,
+      requesterEmail: "ldelplaya@ucsb.edu",
+      teamId: "s22-6pm-3",
+      tableOrBreakoutRoom: "11",
+      requestTime: "2022-04-20T18:31:00",
+      explanation: "Dokku problems",
+      solved: false,
+    },
+    {
+      id: 3,
+      requesterEmail: "pdg@ucsb.edu",
+      teamId: "s22-6pm-4",
+      tableOrBreakoutRoom: "13",
+      requestTime: "2022-04-21T14:15:00",
+      explanation: "Merge conflict",
+      solved: true,
+    },
+  ],
+};
+
+export { helpRequestFixtures };

--- a/frontend/src/main/components/HelpRequests/HelpRequestForm.jsx
+++ b/frontend/src/main/components/HelpRequests/HelpRequestForm.jsx
@@ -1,0 +1,144 @@
+import { Button, Form } from "react-bootstrap";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router";
+
+function HelpRequestForm({
+  initialContents,
+  submitAction,
+  buttonLabel = "Create",
+}) {
+  // Stryker disable all
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm({ defaultValues: initialContents || {} });
+  // Stryker restore all
+
+  const navigate = useNavigate();
+
+  const testIdPrefix = "HelpRequestForm";
+
+  return (
+    <Form onSubmit={handleSubmit(submitAction)}>
+      {initialContents && (
+        <Form.Group className="mb-3">
+          <Form.Label htmlFor="id">Id</Form.Label>
+          <Form.Control
+            data-testid={testIdPrefix + "-id"}
+            id="id"
+            type="text"
+            {...register("id")}
+            value={initialContents.id}
+            disabled
+          />
+        </Form.Group>
+      )}
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="requesterEmail">Requester Email</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-requesterEmail"}
+          id="requesterEmail"
+          type="email"
+          isInvalid={Boolean(errors.requesterEmail)}
+          {...register("requesterEmail", {
+            required: "Requester Email is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.requesterEmail?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="teamId">Team Id</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-teamId"}
+          id="teamId"
+          type="text"
+          isInvalid={Boolean(errors.teamId)}
+          {...register("teamId", {
+            required: "Team Id is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.teamId?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="tableOrBreakoutRoom">
+          Table or Breakout Room
+        </Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-tableOrBreakoutRoom"}
+          id="tableOrBreakoutRoom"
+          type="text"
+          isInvalid={Boolean(errors.tableOrBreakoutRoom)}
+          {...register("tableOrBreakoutRoom", {
+            required: "Table or Breakout Room is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.tableOrBreakoutRoom?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="requestTime">Request Time (ISO format)</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-requestTime"}
+          id="requestTime"
+          type="datetime-local"
+          isInvalid={Boolean(errors.requestTime)}
+          {...register("requestTime", {
+            required: "Request Time is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.requestTime?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="explanation">Explanation</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-explanation"}
+          id="explanation"
+          type="text"
+          isInvalid={Boolean(errors.explanation)}
+          {...register("explanation", {
+            required: "Explanation is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.explanation?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="solved">Solved</Form.Label>
+        <Form.Check
+          data-testid={testIdPrefix + "-solved"}
+          id="solved"
+          type="checkbox"
+          {...register("solved")}
+        />
+      </Form.Group>
+
+      <Button type="submit" data-testid={testIdPrefix + "-submit"}>
+        {buttonLabel}
+      </Button>
+      <Button
+        variant="Secondary"
+        onClick={() => navigate(-1)}
+        data-testid={testIdPrefix + "-cancel"}
+      >
+        Cancel
+      </Button>
+    </Form>
+  );
+}
+
+export default HelpRequestForm;

--- a/frontend/src/tests/components/HelpRequests/HelpRequestForm.test.jsx
+++ b/frontend/src/tests/components/HelpRequests/HelpRequestForm.test.jsx
@@ -43,6 +43,18 @@ describe("HelpRequestForm tests", () => {
       const header = screen.getByText(headerText);
       expect(header).toBeInTheDocument();
     });
+
+    expect(
+      screen.getByTestId(`${testId}-requesterEmail`),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-teamId`)).toBeInTheDocument();
+    expect(
+      screen.getByTestId(`${testId}-tableOrBreakoutRoom`),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-requestTime`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-explanation`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-solved`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-submit`)).toBeInTheDocument();
   });
 
   test("renders correctly when passing in initialContents", async () => {

--- a/frontend/src/tests/components/HelpRequests/HelpRequestForm.test.jsx
+++ b/frontend/src/tests/components/HelpRequests/HelpRequestForm.test.jsx
@@ -1,0 +1,107 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router";
+
+import HelpRequestForm from "main/components/HelpRequests/HelpRequestForm";
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const mockedNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const originalModule = await vi.importActual("react-router");
+  return {
+    ...originalModule,
+    useNavigate: () => mockedNavigate,
+  };
+});
+
+describe("HelpRequestForm tests", () => {
+  const queryClient = new QueryClient();
+
+  const expectedHeaders = [
+    "Requester Email",
+    "Team Id",
+    "Table or Breakout Room",
+    "Request Time (ISO format)",
+    "Explanation",
+    "Solved",
+  ];
+  const testId = "HelpRequestForm";
+
+  test("renders correctly with no initialContents", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <HelpRequestForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+  });
+
+  test("renders correctly when passing in initialContents", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <HelpRequestForm
+            initialContents={helpRequestFixtures.oneHelpRequest}
+          />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(await screen.findByTestId(`${testId}-id`)).toBeInTheDocument();
+    expect(screen.getByText(`Id`)).toBeInTheDocument();
+  });
+
+  test("that navigate(-1) is called when Cancel is clicked", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <HelpRequestForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+    expect(await screen.findByTestId(`${testId}-cancel`)).toBeInTheDocument();
+    const cancelButton = screen.getByTestId(`${testId}-cancel`);
+
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+  });
+
+  test("that the correct validations are performed", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <HelpRequestForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+    const submitButton = screen.getByText(/Create/);
+    fireEvent.click(submitButton);
+
+    await screen.findByText(/Requester Email is required/);
+    expect(screen.getByText(/Team Id is required/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Table or Breakout Room is required/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Request Time is required/)).toBeInTheDocument();
+    expect(screen.getByText(/Explanation is required/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/components/HelpRequests/HelpRequestForm.test.jsx
+++ b/frontend/src/tests/components/HelpRequests/HelpRequestForm.test.jsx
@@ -44,9 +44,7 @@ describe("HelpRequestForm tests", () => {
       expect(header).toBeInTheDocument();
     });
 
-    expect(
-      screen.getByTestId(`${testId}-requesterEmail`),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-requesterEmail`)).toBeInTheDocument();
     expect(screen.getByTestId(`${testId}-teamId`)).toBeInTheDocument();
     expect(
       screen.getByTestId(`${testId}-tableOrBreakoutRoom`),


### PR DESCRIPTION
Added HelpRequestForm with fields: requesterEmail, teamId, tableOrBreakoutRoom, requestTime, explanation, solved. Includes 4 tests for rendering, validation, and cancel navigation.

Closes #40

https://69f15715faec6e353d8ea289-orxgrnrmvw.chromatic.com/?path=/story/pages-helprequests-helprequestcreatepage--default

<img width="2331" height="1049" alt="image" src="https://github.com/user-attachments/assets/d9a4f106-3584-4db6-ad70-ffee1b8a73b8" />