### PR TITLE
Add MenuItemReview table component

### DIFF
--- a/frontend/src/fixtures/menuItemReviewFixtures.js
+++ b/frontend/src/fixtures/menuItemReviewFixtures.js
@@ -1,0 +1,38 @@
+const menuItemReviewFixtures = {
+  oneReview: {
+    id: 1,
+    itemId: 1001,
+    reviewerEmail: "reviewer1@ucsb.edu",
+    stars: 5,
+    dateReviewed: "2026-04-20T12:30:00",
+    comments: "Excellent flavor and generous portion size.",
+  },
+  threeReviews: [
+    {
+      id: 1,
+      itemId: 1001,
+      reviewerEmail: "reviewer1@ucsb.edu",
+      stars: 5,
+      dateReviewed: "2026-04-20T12:30:00",
+      comments: "Excellent flavor and generous portion size.",
+    },
+    {
+      id: 2,
+      itemId: 1002,
+      reviewerEmail: "reviewer2@ucsb.edu",
+      stars: 4,
+      dateReviewed: "2026-04-21T18:45:00",
+      comments: "Good option, but it could use more seasoning.",
+    },
+    {
+      id: 3,
+      itemId: 1003,
+      reviewerEmail: "reviewer3@ucsb.edu",
+      stars: 2,
+      dateReviewed: "2026-04-22T09:15:00",
+      comments: "The item was cold by the time it was served.",
+    },
+  ],
+};
+
+export { menuItemReviewFixtures };

--- a/frontend/src/main/components/MenuItemReview/MenuItemReviewForm.jsx
+++ b/frontend/src/main/components/MenuItemReview/MenuItemReviewForm.jsx
@@ -19,8 +19,6 @@ function MenuItemReviewForm({
   const testIdPrefix = "MenuItemReviewForm";
 
   // Stryker disable Regex
-  const isodateRegex =
-    /(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d)/i;
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/i;
   // Stryker restore Regex
 
@@ -125,10 +123,6 @@ function MenuItemReviewForm({
               isInvalid={Boolean(errors.dateReviewed)}
               {...register("dateReviewed", {
                 required: "Date Reviewed is required.",
-                pattern: {
-                  value: isodateRegex,
-                  message: "Date Reviewed must be in ISO format.",
-                },
               })}
             />
             <Form.Control.Feedback type="invalid">

--- a/frontend/src/main/components/MenuItemReview/MenuItemReviewForm.jsx
+++ b/frontend/src/main/components/MenuItemReview/MenuItemReviewForm.jsx
@@ -1,0 +1,172 @@
+import { Button, Col, Form, Row } from "react-bootstrap";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router";
+
+function MenuItemReviewForm({
+  initialContents,
+  submitAction,
+  buttonLabel = "Create",
+}) {
+  // Stryker disable all
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm({ defaultValues: initialContents || {} });
+  // Stryker restore all
+
+  const navigate = useNavigate();
+  const testIdPrefix = "MenuItemReviewForm";
+
+  // Stryker disable Regex
+  const isodateRegex =
+    /(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d)/i;
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/i;
+  // Stryker restore Regex
+
+  return (
+    <Form onSubmit={handleSubmit(submitAction)}>
+      <Row>
+        {initialContents && (
+          <Col>
+            <Form.Group className="mb-3">
+              <Form.Label htmlFor="id">Id</Form.Label>
+              <Form.Control
+                data-testid={`${testIdPrefix}-id`}
+                id="id"
+                type="text"
+                {...register("id")}
+                value={initialContents.id}
+                disabled
+              />
+            </Form.Group>
+          </Col>
+        )}
+
+        <Col>
+          <Form.Group className="mb-3">
+            <Form.Label htmlFor="itemId">Item Id</Form.Label>
+            <Form.Control
+              data-testid={`${testIdPrefix}-itemId`}
+              id="itemId"
+              type="number"
+              isInvalid={Boolean(errors.itemId)}
+              {...register("itemId", {
+                required: "Item Id is required.",
+                min: {
+                  value: 1,
+                  message: "Item Id must be at least 1.",
+                },
+              })}
+            />
+            <Form.Control.Feedback type="invalid">
+              {errors.itemId?.message}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </Col>
+
+        <Col>
+          <Form.Group className="mb-3">
+            <Form.Label htmlFor="stars">Stars</Form.Label>
+            <Form.Control
+              data-testid={`${testIdPrefix}-stars`}
+              id="stars"
+              type="number"
+              isInvalid={Boolean(errors.stars)}
+              {...register("stars", {
+                required: "Stars is required.",
+                min: {
+                  value: 1,
+                  message: "Stars must be at least 1.",
+                },
+                max: {
+                  value: 5,
+                  message: "Stars must be at most 5.",
+                },
+              })}
+            />
+            <Form.Control.Feedback type="invalid">
+              {errors.stars?.message}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </Col>
+      </Row>
+
+      <Row>
+        <Col>
+          <Form.Group className="mb-3">
+            <Form.Label htmlFor="reviewerEmail">Reviewer Email</Form.Label>
+            <Form.Control
+              data-testid={`${testIdPrefix}-reviewerEmail`}
+              id="reviewerEmail"
+              type="email"
+              isInvalid={Boolean(errors.reviewerEmail)}
+              {...register("reviewerEmail", {
+                required: "Reviewer Email is required.",
+                pattern: {
+                  value: emailRegex,
+                  message: "Reviewer Email must be a valid email address.",
+                },
+              })}
+            />
+            <Form.Control.Feedback type="invalid">
+              {errors.reviewerEmail?.message}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </Col>
+
+        <Col>
+          <Form.Group className="mb-3">
+            <Form.Label htmlFor="dateReviewed">Date Reviewed</Form.Label>
+            <Form.Control
+              data-testid={`${testIdPrefix}-dateReviewed`}
+              id="dateReviewed"
+              type="datetime-local"
+              isInvalid={Boolean(errors.dateReviewed)}
+              {...register("dateReviewed", {
+                required: "Date Reviewed is required.",
+                pattern: {
+                  value: isodateRegex,
+                  message: "Date Reviewed must be in ISO format.",
+                },
+              })}
+            />
+            <Form.Control.Feedback type="invalid">
+              {errors.dateReviewed?.message}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </Col>
+      </Row>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="comments">Comments</Form.Label>
+        <Form.Control
+          data-testid={`${testIdPrefix}-comments`}
+          id="comments"
+          as="textarea"
+          rows={3}
+          isInvalid={Boolean(errors.comments)}
+          {...register("comments", {
+            required: "Comments is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.comments?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Button type="submit" data-testid={`${testIdPrefix}-submit`}>
+        {buttonLabel}
+      </Button>
+      <Button
+        variant="Secondary"
+        onClick={() => navigate(-1)}
+        data-testid={`${testIdPrefix}-cancel`}
+      >
+        Cancel
+      </Button>
+    </Form>
+  );
+}
+
+export default MenuItemReviewForm;

--- a/frontend/src/main/components/MenuItemReview/MenuItemReviewTable.jsx
+++ b/frontend/src/main/components/MenuItemReview/MenuItemReviewTable.jsx
@@ -1,0 +1,71 @@
+import React from "react";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+
+import { useBackendMutation } from "main/utils/useBackend";
+import {
+  cellToAxiosParamsDelete,
+  onDeleteSuccess,
+} from "main/utils/menuItemReviewUtils";
+import { useNavigate } from "react-router";
+import { hasRole } from "main/utils/useCurrentUser";
+
+export default function MenuItemReviewTable({
+  reviews,
+  currentUser,
+  testIdPrefix = "MenuItemReviewTable",
+}) {
+  const navigate = useNavigate();
+
+  const editCallback = (cell) => {
+    navigate(`/menuitemreview/edit/${cell.row.original.id}`);
+  };
+
+  // Stryker disable all : hard to test for query caching
+  const deleteMutation = useBackendMutation(
+    cellToAxiosParamsDelete,
+    { onSuccess: onDeleteSuccess },
+    ["/api/menuitemreview/all"],
+  );
+  // Stryker restore all
+
+  // Stryker disable next-line all : TODO try to make a good test for this
+  const deleteCallback = async (cell) => {
+    deleteMutation.mutate(cell);
+  };
+
+  const columns = [
+    {
+      header: "id",
+      accessorKey: "id",
+    },
+    {
+      header: "Item Id",
+      accessorKey: "itemId",
+    },
+    {
+      header: "Reviewer Email",
+      accessorKey: "reviewerEmail",
+    },
+    {
+      header: "Stars",
+      accessorKey: "stars",
+    },
+    {
+      header: "Date Reviewed",
+      accessorKey: "dateReviewed",
+    },
+    {
+      header: "Comments",
+      accessorKey: "comments",
+    },
+  ];
+
+  if (hasRole(currentUser, "ROLE_ADMIN")) {
+    columns.push(ButtonColumn("Edit", "primary", editCallback, testIdPrefix));
+    columns.push(
+      ButtonColumn("Delete", "danger", deleteCallback, testIdPrefix),
+    );
+  }
+
+  return <OurTable data={reviews} columns={columns} testid={testIdPrefix} />;
+}

--- a/frontend/src/main/utils/menuItemReviewUtils.js
+++ b/frontend/src/main/utils/menuItemReviewUtils.js
@@ -1,0 +1,16 @@
+import { toast } from "react-toastify";
+
+export function onDeleteSuccess(message) {
+  console.log(message);
+  toast(message);
+}
+
+export function cellToAxiosParamsDelete(cell) {
+  return {
+    url: "/api/menuitemreview",
+    method: "DELETE",
+    params: {
+      id: cell.row.original.id,
+    },
+  };
+}

--- a/frontend/src/stories/components/MenuItemReview/MenuItemReviewForm.stories.jsx
+++ b/frontend/src/stories/components/MenuItemReview/MenuItemReviewForm.stories.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import MenuItemReviewForm from "main/components/MenuItemReview/MenuItemReviewForm";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
+
+export default {
+  title: "components/MenuItemReview/MenuItemReviewForm",
+  component: MenuItemReviewForm,
+};
+
+const Template = (args) => {
+  return <MenuItemReviewForm {...args} />;
+};
+
+export const Create = Template.bind({});
+
+Create.args = {
+  buttonLabel: "Create",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};
+
+export const Update = Template.bind({});
+
+Update.args = {
+  initialContents: menuItemReviewFixtures.oneReview,
+  buttonLabel: "Update",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};

--- a/frontend/src/stories/components/MenuItemReview/MenuItemReviewTable.stories.jsx
+++ b/frontend/src/stories/components/MenuItemReview/MenuItemReviewTable.stories.jsx
@@ -1,0 +1,45 @@
+import React from "react";
+import MenuItemReviewTable from "main/components/MenuItemReview/MenuItemReviewTable";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import { http, HttpResponse } from "msw";
+
+export default {
+  title: "components/MenuItemReview/MenuItemReviewTable",
+  component: MenuItemReviewTable,
+};
+
+const Template = (args) => {
+  return <MenuItemReviewTable {...args} />;
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+  reviews: [],
+  currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.args = {
+  reviews: menuItemReviewFixtures.threeReviews,
+  currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+ThreeItemsAdminUser.args = {
+  reviews: menuItemReviewFixtures.threeReviews,
+  currentUser: currentUserFixtures.adminUser,
+};
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.delete("/api/menuitemreview", () => {
+      return HttpResponse.json(
+        { message: "MenuItemReview deleted successfully" },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/tests/components/MenuItemReview/MenuItemReviewForm.test.jsx
+++ b/frontend/src/tests/components/MenuItemReview/MenuItemReviewForm.test.jsx
@@ -1,0 +1,132 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router";
+
+import MenuItemReviewForm from "main/components/MenuItemReview/MenuItemReviewForm";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const mockedNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const originalModule = await vi.importActual("react-router");
+  return {
+    ...originalModule,
+    useNavigate: () => mockedNavigate,
+  };
+});
+
+describe("MenuItemReviewForm tests", () => {
+  const queryClient = new QueryClient();
+
+  const expectedHeaders = [
+    "Item Id",
+    "Stars",
+    "Reviewer Email",
+    "Date Reviewed",
+    "Comments",
+  ];
+  const testId = "MenuItemReviewForm";
+
+  test("renders correctly with no initialContents", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <MenuItemReviewForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId(`${testId}-id`)).not.toBeInTheDocument();
+  });
+
+  test("renders correctly when passing in initialContents", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <MenuItemReviewForm
+            initialContents={menuItemReviewFixtures.oneReview}
+          />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(await screen.findByTestId(`${testId}-id`)).toBeInTheDocument();
+    expect(screen.getByText("Id")).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-id`)).toHaveValue("1");
+    expect(screen.getByTestId(`${testId}-itemId`)).toHaveValue(1001);
+    expect(screen.getByTestId(`${testId}-reviewerEmail`)).toHaveValue(
+      "reviewer1@ucsb.edu",
+    );
+  });
+
+  test("that navigate(-1) is called when Cancel is clicked", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <MenuItemReviewForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+    expect(await screen.findByTestId(`${testId}-cancel`)).toBeInTheDocument();
+    const cancelButton = screen.getByTestId(`${testId}-cancel`);
+
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+  });
+
+  test("that the correct validations are performed", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <MenuItemReviewForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+    const submitButton = screen.getByText(/Create/);
+    fireEvent.click(submitButton);
+
+    expect(await screen.findByText(/Item Id is required/)).toBeInTheDocument();
+    expect(screen.getByText(/Stars is required/)).toBeInTheDocument();
+    expect(screen.getByText(/Reviewer Email is required/)).toBeInTheDocument();
+    expect(screen.getByText(/Date Reviewed is required/)).toBeInTheDocument();
+    expect(screen.getByText(/Comments is required/)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId(`${testId}-itemId`), {
+      target: { value: "0" },
+    });
+    fireEvent.change(screen.getByTestId(`${testId}-stars`), {
+      target: { value: "6" },
+    });
+    fireEvent.change(screen.getByTestId(`${testId}-reviewerEmail`), {
+      target: { value: "not-an-email" },
+    });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Item Id must be at least 1/),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Stars must be at most 5/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Reviewer Email must be a valid email address/),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/components/MenuItemReview/MenuItemReviewForm.test.jsx
+++ b/frontend/src/tests/components/MenuItemReview/MenuItemReviewForm.test.jsx
@@ -44,6 +44,12 @@ describe("MenuItemReviewForm tests", () => {
     });
 
     expect(screen.queryByTestId(`${testId}-id`)).not.toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-itemId`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-stars`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-reviewerEmail`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-dateReviewed`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-comments`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-submit`)).toBeInTheDocument();
   });
 
   test("renders correctly when passing in initialContents", async () => {
@@ -68,8 +74,15 @@ describe("MenuItemReviewForm tests", () => {
     expect(screen.getByText("Id")).toBeInTheDocument();
     expect(screen.getByTestId(`${testId}-id`)).toHaveValue("1");
     expect(screen.getByTestId(`${testId}-itemId`)).toHaveValue(1001);
+    expect(screen.getByTestId(`${testId}-stars`)).toHaveValue(5);
     expect(screen.getByTestId(`${testId}-reviewerEmail`)).toHaveValue(
       "reviewer1@ucsb.edu",
+    );
+    expect(screen.getByTestId(`${testId}-dateReviewed`)).toHaveValue(
+      "2026-04-20T12:30",
+    );
+    expect(screen.getByTestId(`${testId}-comments`)).toHaveValue(
+      "Excellent flavor and generous portion size.",
     );
   });
 
@@ -99,7 +112,7 @@ describe("MenuItemReviewForm tests", () => {
     );
 
     expect(await screen.findByText(/Create/)).toBeInTheDocument();
-    const submitButton = screen.getByText(/Create/);
+    const submitButton = screen.getByTestId(`${testId}-submit`);
     fireEvent.click(submitButton);
 
     expect(await screen.findByText(/Item Id is required/)).toBeInTheDocument();
@@ -111,6 +124,15 @@ describe("MenuItemReviewForm tests", () => {
     fireEvent.change(screen.getByTestId(`${testId}-itemId`), {
       target: { value: "0" },
     });
+    fireEvent.change(screen.getByTestId(`${testId}-stars`), {
+      target: { value: "0" },
+    });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Stars must be at least 1/)).toBeInTheDocument();
+    });
+
     fireEvent.change(screen.getByTestId(`${testId}-stars`), {
       target: { value: "6" },
     });

--- a/frontend/src/tests/components/MenuItemReview/MenuItemReviewTable.test.jsx
+++ b/frontend/src/tests/components/MenuItemReview/MenuItemReviewTable.test.jsx
@@ -1,0 +1,203 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
+import MenuItemReviewTable from "main/components/MenuItemReview/MenuItemReviewTable";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockedNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const originalModule = await vi.importActual("react-router");
+  return {
+    ...originalModule,
+    useNavigate: () => mockedNavigate,
+  };
+});
+
+describe("MenuItemReviewTable tests", () => {
+  const queryClient = new QueryClient();
+
+  const expectedHeaders = [
+    "id",
+    "Item Id",
+    "Reviewer Email",
+    "Stars",
+    "Date Reviewed",
+    "Comments",
+  ];
+  const expectedFields = [
+    "id",
+    "itemId",
+    "reviewerEmail",
+    "stars",
+    "dateReviewed",
+    "comments",
+  ];
+  const testId = "MenuItemReviewTable";
+
+  test("renders empty table correctly", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewTable reviews={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const fieldElement = screen.queryByTestId(
+        `${testId}-cell-row-0-col-${field}`,
+      );
+      expect(fieldElement).not.toBeInTheDocument();
+    });
+  });
+
+  test("Has the expected column headers, content and buttons for admin user", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewTable
+            reviews={menuItemReviewFixtures.threeReviews}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const cell = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(cell).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-reviewerEmail`),
+    ).toHaveTextContent("reviewer1@ucsb.edu");
+
+    const editButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
+    );
+    expect(editButton).toBeInTheDocument();
+    expect(editButton).toHaveClass("btn-primary");
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
+  });
+
+  test("Has the expected column headers, content for ordinary user", () => {
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewTable
+            reviews={menuItemReviewFixtures.threeReviews}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const cell = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(cell).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-comments`),
+    ).toHaveTextContent("Good option, but it could use more seasoning.");
+
+    expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+    expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+  });
+
+  test("Edit button navigates to the edit page", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewTable
+            reviews={menuItemReviewFixtures.threeReviews}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      await screen.findByTestId(`${testId}-cell-row-0-col-id`),
+    ).toHaveTextContent("1");
+
+    const editButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
+    );
+    fireEvent.click(editButton);
+
+    await waitFor(() =>
+      expect(mockedNavigate).toHaveBeenCalledWith("/menuitemreview/edit/1"),
+    );
+  });
+
+  test("Delete button calls delete callback", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    const axiosMock = new AxiosMockAdapter(axios);
+    axiosMock
+      .onDelete("/api/menuitemreview")
+      .reply(200, { message: "MenuItemReview deleted" });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewTable
+            reviews={menuItemReviewFixtures.threeReviews}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      await screen.findByTestId(`${testId}-cell-row-0-col-id`),
+    ).toHaveTextContent("1");
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => expect(axiosMock.history.delete.length).toBe(1));
+    expect(axiosMock.history.delete[0].params).toEqual({ id: 1 });
+    axiosMock.restore();
+  });
+});

--- a/frontend/src/tests/components/MenuItemReview/MenuItemReviewTable.test.jsx
+++ b/frontend/src/tests/components/MenuItemReview/MenuItemReviewTable.test.jsx
@@ -6,6 +6,19 @@ import { MemoryRouter } from "react-router";
 import { currentUserFixtures } from "fixtures/currentUserFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import {
+  cellToAxiosParamsDelete,
+  onDeleteSuccess,
+} from "main/utils/menuItemReviewUtils";
+
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
 
 const mockedNavigate = vi.fn();
 vi.mock("react-router", async () => {
@@ -18,6 +31,10 @@ vi.mock("react-router", async () => {
 
 describe("MenuItemReviewTable tests", () => {
   const queryClient = new QueryClient();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
   const expectedHeaders = [
     "id",
@@ -166,6 +183,23 @@ describe("MenuItemReviewTable tests", () => {
     await waitFor(() =>
       expect(mockedNavigate).toHaveBeenCalledWith("/menuitemreview/edit/1"),
     );
+  });
+
+  test("cellToAxiosParamsDelete returns the correct params", () => {
+    const cell = { row: { original: { id: 17 } } };
+    expect(cellToAxiosParamsDelete(cell)).toEqual({
+      url: "/api/menuitemreview",
+      method: "DELETE",
+      params: { id: 17 },
+    });
+  });
+
+  test("onDeleteSuccess logs and toasts the message", () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    onDeleteSuccess("MenuItemReview deleted");
+    expect(consoleSpy).toHaveBeenCalledWith("MenuItemReview deleted");
+    expect(mockToast).toHaveBeenCalledWith("MenuItemReview deleted");
+    consoleSpy.mockRestore();
   });
 
   test("Delete button calls delete callback", async () => {


### PR DESCRIPTION
## Summary
- Adds the `MenuItemReviewTable` component.
- Displays all `MenuItemReview` fields in a user-friendly table.
- Shows `Edit` and `Delete` buttons for admins and read-only rows for ordinary users.
- Adds Storybook stories, component tests, and delete utility coverage.

## Storybook
- Direct story link: https://69f15715faec6e353d8ea289-bpekrntzmt.chromatic.com/?path=/story/components-menuitemreview-menuitemreviewtable--empty
- Direct story link: https://69f15715faec6e353d8ea289-bpekrntzmt.chromatic.com/?path=/story/components-menuitemreview-menuitemreviewtable--three-items-ordinary-user
- Direct story link: https://69f15715faec6e353d8ea289-bpekrntzmt.chromatic.com/?path=/story/components-menuitemreview-menuitemreviewtable--three-items-admin-user

## Manual Testing
1. Run Storybook locally or open the published Storybook link above.
2. Open the `Empty` story and confirm the table headers render correctly with no rows.
3. Open the ordinary user story and confirm the rows render with all expected columns.
4. Confirm the ordinary user story does not show `Edit` or `Delete` buttons.
5. Open the admin story and confirm both `Edit` and `Delete` buttons are visible.
6. Confirm the mocked delete interaction succeeds in the admin story.

## Screenshot
<img width="1212" height="95" alt="image" src="https://github.com/user-attachments/assets/c9f7ef73-772f-4472-8fdb-5a92f5fe7ab6" />
<img width="1190" height="184" alt="image" src="https://github.com/user-attachments/assets/f35f85b2-5408-4b58-bcb2-4081a901f4b7" />
<img width="1194" height="234" alt="image" src="https://github.com/user-attachments/assets/7931b196-c9f0-4c89-b642-0fe6518f0db8" />


## Automated Testing
- `npm --prefix frontend test`
- `npm --prefix frontend run lint`
- `cd frontend && npx stryker run --mutate 'src/main/components/MenuItemReview/MenuItemReviewTable.jsx,src/main/utils/menuItemReviewUtils.js'`

Closes #32
