### PR TITLE
Add MenuItemReview index page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,10 @@ import RestaurantIndexPage from "main/pages/Restaurants/RestaurantIndexPage";
 import RestaurantCreatePage from "main/pages/Restaurants/RestaurantCreatePage";
 import RestaurantEditPage from "main/pages/Restaurants/RestaurantEditPage";
 
+import MenuItemReviewIndexPage from "main/pages/MenuItemReview/MenuItemReviewIndexPage";
+import MenuItemReviewCreatePage from "main/pages/MenuItemReview/MenuItemReviewCreatePage";
+import MenuItemReviewEditPage from "main/pages/MenuItemReview/MenuItemReviewEditPage";
+
 import PlaceholderIndexPage from "main/pages/Placeholder/PlaceholderIndexPage";
 import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage";
 import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
@@ -69,6 +73,29 @@ function App() {
             exact
             path="/restaurants/create"
             element={<RestaurantCreatePage />}
+          />
+        </>
+      )}
+      {hasRole(currentUser, "ROLE_USER") && (
+        <>
+          <Route
+            exact
+            path="/menuitemreview"
+            element={<MenuItemReviewIndexPage />}
+          />
+        </>
+      )}
+      {hasRole(currentUser, "ROLE_ADMIN") && (
+        <>
+          <Route
+            exact
+            path="/menuitemreview/edit/:id"
+            element={<MenuItemReviewEditPage />}
+          />
+          <Route
+            exact
+            path="/menuitemreview/create"
+            element={<MenuItemReviewCreatePage />}
           />
         </>
       )}

--- a/frontend/src/main/components/MenuItemReview/MenuItemReviewForm.jsx
+++ b/frontend/src/main/components/MenuItemReview/MenuItemReviewForm.jsx
@@ -19,8 +19,6 @@ function MenuItemReviewForm({
   const testIdPrefix = "MenuItemReviewForm";
 
   // Stryker disable Regex
-  const isodateRegex =
-    /(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d)/i;
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/i;
   // Stryker restore Regex
 
@@ -125,10 +123,6 @@ function MenuItemReviewForm({
               isInvalid={Boolean(errors.dateReviewed)}
               {...register("dateReviewed", {
                 required: "Date Reviewed is required.",
-                pattern: {
-                  value: isodateRegex,
-                  message: "Date Reviewed must be in ISO format.",
-                },
               })}
             />
             <Form.Control.Feedback type="invalid">

--- a/frontend/src/main/components/MenuItemReview/MenuItemReviewForm.jsx
+++ b/frontend/src/main/components/MenuItemReview/MenuItemReviewForm.jsx
@@ -1,0 +1,172 @@
+import { Button, Col, Form, Row } from "react-bootstrap";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router";
+
+function MenuItemReviewForm({
+  initialContents,
+  submitAction,
+  buttonLabel = "Create",
+}) {
+  // Stryker disable all
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm({ defaultValues: initialContents || {} });
+  // Stryker restore all
+
+  const navigate = useNavigate();
+  const testIdPrefix = "MenuItemReviewForm";
+
+  // Stryker disable Regex
+  const isodateRegex =
+    /(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d)/i;
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/i;
+  // Stryker restore Regex
+
+  return (
+    <Form onSubmit={handleSubmit(submitAction)}>
+      <Row>
+        {initialContents && (
+          <Col>
+            <Form.Group className="mb-3">
+              <Form.Label htmlFor="id">Id</Form.Label>
+              <Form.Control
+                data-testid={`${testIdPrefix}-id`}
+                id="id"
+                type="text"
+                {...register("id")}
+                value={initialContents.id}
+                disabled
+              />
+            </Form.Group>
+          </Col>
+        )}
+
+        <Col>
+          <Form.Group className="mb-3">
+            <Form.Label htmlFor="itemId">Item Id</Form.Label>
+            <Form.Control
+              data-testid={`${testIdPrefix}-itemId`}
+              id="itemId"
+              type="number"
+              isInvalid={Boolean(errors.itemId)}
+              {...register("itemId", {
+                required: "Item Id is required.",
+                min: {
+                  value: 1,
+                  message: "Item Id must be at least 1.",
+                },
+              })}
+            />
+            <Form.Control.Feedback type="invalid">
+              {errors.itemId?.message}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </Col>
+
+        <Col>
+          <Form.Group className="mb-3">
+            <Form.Label htmlFor="stars">Stars</Form.Label>
+            <Form.Control
+              data-testid={`${testIdPrefix}-stars`}
+              id="stars"
+              type="number"
+              isInvalid={Boolean(errors.stars)}
+              {...register("stars", {
+                required: "Stars is required.",
+                min: {
+                  value: 1,
+                  message: "Stars must be at least 1.",
+                },
+                max: {
+                  value: 5,
+                  message: "Stars must be at most 5.",
+                },
+              })}
+            />
+            <Form.Control.Feedback type="invalid">
+              {errors.stars?.message}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </Col>
+      </Row>
+
+      <Row>
+        <Col>
+          <Form.Group className="mb-3">
+            <Form.Label htmlFor="reviewerEmail">Reviewer Email</Form.Label>
+            <Form.Control
+              data-testid={`${testIdPrefix}-reviewerEmail`}
+              id="reviewerEmail"
+              type="email"
+              isInvalid={Boolean(errors.reviewerEmail)}
+              {...register("reviewerEmail", {
+                required: "Reviewer Email is required.",
+                pattern: {
+                  value: emailRegex,
+                  message: "Reviewer Email must be a valid email address.",
+                },
+              })}
+            />
+            <Form.Control.Feedback type="invalid">
+              {errors.reviewerEmail?.message}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </Col>
+
+        <Col>
+          <Form.Group className="mb-3">
+            <Form.Label htmlFor="dateReviewed">Date Reviewed</Form.Label>
+            <Form.Control
+              data-testid={`${testIdPrefix}-dateReviewed`}
+              id="dateReviewed"
+              type="datetime-local"
+              isInvalid={Boolean(errors.dateReviewed)}
+              {...register("dateReviewed", {
+                required: "Date Reviewed is required.",
+                pattern: {
+                  value: isodateRegex,
+                  message: "Date Reviewed must be in ISO format.",
+                },
+              })}
+            />
+            <Form.Control.Feedback type="invalid">
+              {errors.dateReviewed?.message}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </Col>
+      </Row>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="comments">Comments</Form.Label>
+        <Form.Control
+          data-testid={`${testIdPrefix}-comments`}
+          id="comments"
+          as="textarea"
+          rows={3}
+          isInvalid={Boolean(errors.comments)}
+          {...register("comments", {
+            required: "Comments is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.comments?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Button type="submit" data-testid={`${testIdPrefix}-submit`}>
+        {buttonLabel}
+      </Button>
+      <Button
+        variant="Secondary"
+        onClick={() => navigate(-1)}
+        data-testid={`${testIdPrefix}-cancel`}
+      >
+        Cancel
+      </Button>
+    </Form>
+  );
+}
+
+export default MenuItemReviewForm;

--- a/frontend/src/main/components/MenuItemReview/MenuItemReviewTable.jsx
+++ b/frontend/src/main/components/MenuItemReview/MenuItemReviewTable.jsx
@@ -1,0 +1,71 @@
+import React from "react";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+
+import { useBackendMutation } from "main/utils/useBackend";
+import {
+  cellToAxiosParamsDelete,
+  onDeleteSuccess,
+} from "main/utils/menuItemReviewUtils";
+import { useNavigate } from "react-router";
+import { hasRole } from "main/utils/useCurrentUser";
+
+export default function MenuItemReviewTable({
+  reviews,
+  currentUser,
+  testIdPrefix = "MenuItemReviewTable",
+}) {
+  const navigate = useNavigate();
+
+  const editCallback = (cell) => {
+    navigate(`/menuitemreview/edit/${cell.row.original.id}`);
+  };
+
+  // Stryker disable all : hard to test for query caching
+  const deleteMutation = useBackendMutation(
+    cellToAxiosParamsDelete,
+    { onSuccess: onDeleteSuccess },
+    ["/api/menuitemreview/all"],
+  );
+  // Stryker restore all
+
+  // Stryker disable next-line all : TODO try to make a good test for this
+  const deleteCallback = async (cell) => {
+    deleteMutation.mutate(cell);
+  };
+
+  const columns = [
+    {
+      header: "id",
+      accessorKey: "id",
+    },
+    {
+      header: "Item Id",
+      accessorKey: "itemId",
+    },
+    {
+      header: "Reviewer Email",
+      accessorKey: "reviewerEmail",
+    },
+    {
+      header: "Stars",
+      accessorKey: "stars",
+    },
+    {
+      header: "Date Reviewed",
+      accessorKey: "dateReviewed",
+    },
+    {
+      header: "Comments",
+      accessorKey: "comments",
+    },
+  ];
+
+  if (hasRole(currentUser, "ROLE_ADMIN")) {
+    columns.push(ButtonColumn("Edit", "primary", editCallback, testIdPrefix));
+    columns.push(
+      ButtonColumn("Delete", "danger", deleteCallback, testIdPrefix),
+    );
+  }
+
+  return <OurTable data={reviews} columns={columns} testid={testIdPrefix} />;
+}

--- a/frontend/src/main/components/Nav/AppNavbar.jsx
+++ b/frontend/src/main/components/Nav/AppNavbar.jsx
@@ -68,6 +68,9 @@ export default function AppNavbar({
                   <Nav.Link as={Link} to="/ucsbdates">
                     UCSB Dates
                   </Nav.Link>
+                  <Nav.Link as={Link} to="/menuitemreview">
+                    MenuItemReview
+                  </Nav.Link>
                   <Nav.Link as={Link} to="/placeholder">
                     Placeholder
                   </Nav.Link>

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewCreatePage.jsx
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewCreatePage.jsx
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function MenuItemReviewCreatePage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Create page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewCreatePage.jsx
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewCreatePage.jsx
@@ -1,11 +1,48 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import MenuItemReviewForm from "main/components/MenuItemReview/MenuItemReviewForm";
+import { Navigate } from "react-router";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function MenuItemReviewCreatePage() {
-  // Stryker disable all : placeholder for future implementation
+export default function MenuItemReviewCreatePage({ storybook = false }) {
+  const objectToAxiosParams = (review) => ({
+    url: "/api/menuitemreview/post",
+    method: "POST",
+    params: {
+      itemId: review.itemId,
+      reviewerEmail: review.reviewerEmail,
+      stars: review.stars,
+      dateReviewed: review.dateReviewed,
+      comments: review.comments,
+    },
+  });
+
+  const onSuccess = (review) => {
+    toast(`New MenuItemReview Created - id: ${review.id}`);
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    ["/api/menuitemreview/all"],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/menuitemreview" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create New MenuItemReview</h1>
+        <MenuItemReviewForm submitAction={onSubmit} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewEditPage.jsx
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewEditPage.jsx
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function MenuItemReviewEditPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Edit page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewIndexPage.jsx
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewIndexPage.jsx
@@ -1,0 +1,18 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function MenuItemReviewIndexPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Index page not yet implemented</h1>
+        <p>
+          <a href="/menuitemreview/create">Create</a>
+        </p>
+        <p>
+          <a href="/menuitemreview/edit/1">Edit</a>
+        </p>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewIndexPage.jsx
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewIndexPage.jsx
@@ -1,17 +1,46 @@
+import React from "react";
+import { useBackend } from "main/utils/useBackend";
+
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import MenuItemReviewTable from "main/components/MenuItemReview/MenuItemReviewTable";
+import { useCurrentUser, hasRole } from "main/utils/useCurrentUser";
+import { Button } from "react-bootstrap";
 
 export default function MenuItemReviewIndexPage() {
-  // Stryker disable all : placeholder for future implementation
+  const currentUser = useCurrentUser();
+
+  const {
+    data: reviews,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/menuitemreview/all"],
+    { method: "GET", url: "/api/menuitemreview/all" },
+    // Stryker disable next-line all : don't test default value of empty list
+    [],
+  );
+
+  const createButton = () => {
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+      return (
+        <Button
+          variant="primary"
+          href="/menuitemreview/create"
+          style={{ float: "right" }}
+        >
+          Create MenuItemReview
+        </Button>
+      );
+    }
+  };
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Index page not yet implemented</h1>
-        <p>
-          <a href="/menuitemreview/create">Create</a>
-        </p>
-        <p>
-          <a href="/menuitemreview/edit/1">Edit</a>
-        </p>
+        {createButton()}
+        <h1>MenuItemReview</h1>
+        <MenuItemReviewTable reviews={reviews} currentUser={currentUser} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/utils/menuItemReviewUtils.js
+++ b/frontend/src/main/utils/menuItemReviewUtils.js
@@ -1,0 +1,16 @@
+import { toast } from "react-toastify";
+
+export function onDeleteSuccess(message) {
+  console.log(message);
+  toast(message);
+}
+
+export function cellToAxiosParamsDelete(cell) {
+  return {
+    url: "/api/menuitemreview",
+    method: "DELETE",
+    params: {
+      id: cell.row.original.id,
+    },
+  };
+}

--- a/frontend/src/stories/components/MenuItemReview/MenuItemReviewForm.stories.jsx
+++ b/frontend/src/stories/components/MenuItemReview/MenuItemReviewForm.stories.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import MenuItemReviewForm from "main/components/MenuItemReview/MenuItemReviewForm";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
+
+export default {
+  title: "components/MenuItemReview/MenuItemReviewForm",
+  component: MenuItemReviewForm,
+};
+
+const Template = (args) => {
+  return <MenuItemReviewForm {...args} />;
+};
+
+export const Create = Template.bind({});
+
+Create.args = {
+  buttonLabel: "Create",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};
+
+export const Update = Template.bind({});
+
+Update.args = {
+  initialContents: menuItemReviewFixtures.oneReview,
+  buttonLabel: "Update",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};

--- a/frontend/src/stories/components/MenuItemReview/MenuItemReviewTable.stories.jsx
+++ b/frontend/src/stories/components/MenuItemReview/MenuItemReviewTable.stories.jsx
@@ -1,0 +1,45 @@
+import React from "react";
+import MenuItemReviewTable from "main/components/MenuItemReview/MenuItemReviewTable";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import { http, HttpResponse } from "msw";
+
+export default {
+  title: "components/MenuItemReview/MenuItemReviewTable",
+  component: MenuItemReviewTable,
+};
+
+const Template = (args) => {
+  return <MenuItemReviewTable {...args} />;
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+  reviews: [],
+  currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.args = {
+  reviews: menuItemReviewFixtures.threeReviews,
+  currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+ThreeItemsAdminUser.args = {
+  reviews: menuItemReviewFixtures.threeReviews,
+  currentUser: currentUserFixtures.adminUser,
+};
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.delete("/api/menuitemreview", () => {
+      return HttpResponse.json(
+        { message: "MenuItemReview deleted successfully" },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/stories/pages/MenuItemReview/MenuItemReviewCreatePage.stories.jsx
+++ b/frontend/src/stories/pages/MenuItemReview/MenuItemReviewCreatePage.stories.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import MenuItemReviewCreatePage from "main/pages/MenuItemReview/MenuItemReviewCreatePage";
+
+export default {
+  title: "pages/MenuItemReview/MenuItemReviewCreatePage",
+  component: MenuItemReviewCreatePage,
+};
+
+const Template = () => <MenuItemReviewCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.post("/api/menuitemreview/post", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/stories/pages/MenuItemReview/MenuItemReviewIndexPage.stories.jsx
+++ b/frontend/src/stories/pages/MenuItemReview/MenuItemReviewIndexPage.stories.jsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
+import { http, HttpResponse } from "msw";
+
+import MenuItemReviewIndexPage from "main/pages/MenuItemReview/MenuItemReviewIndexPage";
+
+export default {
+  title: "pages/MenuItemReview/MenuItemReviewIndexPage",
+  component: MenuItemReviewIndexPage,
+};
+
+const Template = () => <MenuItemReviewIndexPage storybook={true} />;
+
+export const Empty = Template.bind({});
+Empty.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/menuitemreview/all", () => {
+      return HttpResponse.json([], { status: 200 });
+    }),
+  ],
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/menuitemreview/all", () => {
+      return HttpResponse.json(menuItemReviewFixtures.threeReviews);
+    }),
+  ],
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.adminUser);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/menuitemreview/all", () => {
+      return HttpResponse.json(menuItemReviewFixtures.threeReviews);
+    }),
+    http.delete("/api/menuitemreview", () => {
+      return HttpResponse.json(
+        { message: "MenuItemReview deleted successfully" },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/tests/components/MenuItemReview/MenuItemReviewForm.test.jsx
+++ b/frontend/src/tests/components/MenuItemReview/MenuItemReviewForm.test.jsx
@@ -1,0 +1,132 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router";
+
+import MenuItemReviewForm from "main/components/MenuItemReview/MenuItemReviewForm";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const mockedNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const originalModule = await vi.importActual("react-router");
+  return {
+    ...originalModule,
+    useNavigate: () => mockedNavigate,
+  };
+});
+
+describe("MenuItemReviewForm tests", () => {
+  const queryClient = new QueryClient();
+
+  const expectedHeaders = [
+    "Item Id",
+    "Stars",
+    "Reviewer Email",
+    "Date Reviewed",
+    "Comments",
+  ];
+  const testId = "MenuItemReviewForm";
+
+  test("renders correctly with no initialContents", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <MenuItemReviewForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId(`${testId}-id`)).not.toBeInTheDocument();
+  });
+
+  test("renders correctly when passing in initialContents", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <MenuItemReviewForm
+            initialContents={menuItemReviewFixtures.oneReview}
+          />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(await screen.findByTestId(`${testId}-id`)).toBeInTheDocument();
+    expect(screen.getByText("Id")).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-id`)).toHaveValue("1");
+    expect(screen.getByTestId(`${testId}-itemId`)).toHaveValue(1001);
+    expect(screen.getByTestId(`${testId}-reviewerEmail`)).toHaveValue(
+      "reviewer1@ucsb.edu",
+    );
+  });
+
+  test("that navigate(-1) is called when Cancel is clicked", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <MenuItemReviewForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+    expect(await screen.findByTestId(`${testId}-cancel`)).toBeInTheDocument();
+    const cancelButton = screen.getByTestId(`${testId}-cancel`);
+
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+  });
+
+  test("that the correct validations are performed", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <MenuItemReviewForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+    const submitButton = screen.getByText(/Create/);
+    fireEvent.click(submitButton);
+
+    expect(await screen.findByText(/Item Id is required/)).toBeInTheDocument();
+    expect(screen.getByText(/Stars is required/)).toBeInTheDocument();
+    expect(screen.getByText(/Reviewer Email is required/)).toBeInTheDocument();
+    expect(screen.getByText(/Date Reviewed is required/)).toBeInTheDocument();
+    expect(screen.getByText(/Comments is required/)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId(`${testId}-itemId`), {
+      target: { value: "0" },
+    });
+    fireEvent.change(screen.getByTestId(`${testId}-stars`), {
+      target: { value: "6" },
+    });
+    fireEvent.change(screen.getByTestId(`${testId}-reviewerEmail`), {
+      target: { value: "not-an-email" },
+    });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Item Id must be at least 1/),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Stars must be at most 5/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Reviewer Email must be a valid email address/),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/components/MenuItemReview/MenuItemReviewForm.test.jsx
+++ b/frontend/src/tests/components/MenuItemReview/MenuItemReviewForm.test.jsx
@@ -44,6 +44,12 @@ describe("MenuItemReviewForm tests", () => {
     });
 
     expect(screen.queryByTestId(`${testId}-id`)).not.toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-itemId`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-stars`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-reviewerEmail`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-dateReviewed`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-comments`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-submit`)).toBeInTheDocument();
   });
 
   test("renders correctly when passing in initialContents", async () => {
@@ -68,8 +74,15 @@ describe("MenuItemReviewForm tests", () => {
     expect(screen.getByText("Id")).toBeInTheDocument();
     expect(screen.getByTestId(`${testId}-id`)).toHaveValue("1");
     expect(screen.getByTestId(`${testId}-itemId`)).toHaveValue(1001);
+    expect(screen.getByTestId(`${testId}-stars`)).toHaveValue(5);
     expect(screen.getByTestId(`${testId}-reviewerEmail`)).toHaveValue(
       "reviewer1@ucsb.edu",
+    );
+    expect(screen.getByTestId(`${testId}-dateReviewed`)).toHaveValue(
+      "2026-04-20T12:30",
+    );
+    expect(screen.getByTestId(`${testId}-comments`)).toHaveValue(
+      "Excellent flavor and generous portion size.",
     );
   });
 
@@ -99,7 +112,7 @@ describe("MenuItemReviewForm tests", () => {
     );
 
     expect(await screen.findByText(/Create/)).toBeInTheDocument();
-    const submitButton = screen.getByText(/Create/);
+    const submitButton = screen.getByTestId(`${testId}-submit`);
     fireEvent.click(submitButton);
 
     expect(await screen.findByText(/Item Id is required/)).toBeInTheDocument();
@@ -111,6 +124,15 @@ describe("MenuItemReviewForm tests", () => {
     fireEvent.change(screen.getByTestId(`${testId}-itemId`), {
       target: { value: "0" },
     });
+    fireEvent.change(screen.getByTestId(`${testId}-stars`), {
+      target: { value: "0" },
+    });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Stars must be at least 1/)).toBeInTheDocument();
+    });
+
     fireEvent.change(screen.getByTestId(`${testId}-stars`), {
       target: { value: "6" },
     });

--- a/frontend/src/tests/components/MenuItemReview/MenuItemReviewTable.test.jsx
+++ b/frontend/src/tests/components/MenuItemReview/MenuItemReviewTable.test.jsx
@@ -1,0 +1,203 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
+import MenuItemReviewTable from "main/components/MenuItemReview/MenuItemReviewTable";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockedNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const originalModule = await vi.importActual("react-router");
+  return {
+    ...originalModule,
+    useNavigate: () => mockedNavigate,
+  };
+});
+
+describe("MenuItemReviewTable tests", () => {
+  const queryClient = new QueryClient();
+
+  const expectedHeaders = [
+    "id",
+    "Item Id",
+    "Reviewer Email",
+    "Stars",
+    "Date Reviewed",
+    "Comments",
+  ];
+  const expectedFields = [
+    "id",
+    "itemId",
+    "reviewerEmail",
+    "stars",
+    "dateReviewed",
+    "comments",
+  ];
+  const testId = "MenuItemReviewTable";
+
+  test("renders empty table correctly", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewTable reviews={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const fieldElement = screen.queryByTestId(
+        `${testId}-cell-row-0-col-${field}`,
+      );
+      expect(fieldElement).not.toBeInTheDocument();
+    });
+  });
+
+  test("Has the expected column headers, content and buttons for admin user", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewTable
+            reviews={menuItemReviewFixtures.threeReviews}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const cell = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(cell).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-reviewerEmail`),
+    ).toHaveTextContent("reviewer1@ucsb.edu");
+
+    const editButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
+    );
+    expect(editButton).toBeInTheDocument();
+    expect(editButton).toHaveClass("btn-primary");
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
+  });
+
+  test("Has the expected column headers, content for ordinary user", () => {
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewTable
+            reviews={menuItemReviewFixtures.threeReviews}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const cell = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(cell).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-comments`),
+    ).toHaveTextContent("Good option, but it could use more seasoning.");
+
+    expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+    expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+  });
+
+  test("Edit button navigates to the edit page", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewTable
+            reviews={menuItemReviewFixtures.threeReviews}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      await screen.findByTestId(`${testId}-cell-row-0-col-id`),
+    ).toHaveTextContent("1");
+
+    const editButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
+    );
+    fireEvent.click(editButton);
+
+    await waitFor(() =>
+      expect(mockedNavigate).toHaveBeenCalledWith("/menuitemreview/edit/1"),
+    );
+  });
+
+  test("Delete button calls delete callback", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    const axiosMock = new AxiosMockAdapter(axios);
+    axiosMock
+      .onDelete("/api/menuitemreview")
+      .reply(200, { message: "MenuItemReview deleted" });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewTable
+            reviews={menuItemReviewFixtures.threeReviews}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      await screen.findByTestId(`${testId}-cell-row-0-col-id`),
+    ).toHaveTextContent("1");
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => expect(axiosMock.history.delete.length).toBe(1));
+    expect(axiosMock.history.delete[0].params).toEqual({ id: 1 });
+    axiosMock.restore();
+  });
+});

--- a/frontend/src/tests/components/MenuItemReview/MenuItemReviewTable.test.jsx
+++ b/frontend/src/tests/components/MenuItemReview/MenuItemReviewTable.test.jsx
@@ -6,6 +6,19 @@ import { MemoryRouter } from "react-router";
 import { currentUserFixtures } from "fixtures/currentUserFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import {
+  cellToAxiosParamsDelete,
+  onDeleteSuccess,
+} from "main/utils/menuItemReviewUtils";
+
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
 
 const mockedNavigate = vi.fn();
 vi.mock("react-router", async () => {
@@ -18,6 +31,10 @@ vi.mock("react-router", async () => {
 
 describe("MenuItemReviewTable tests", () => {
   const queryClient = new QueryClient();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
   const expectedHeaders = [
     "id",
@@ -166,6 +183,23 @@ describe("MenuItemReviewTable tests", () => {
     await waitFor(() =>
       expect(mockedNavigate).toHaveBeenCalledWith("/menuitemreview/edit/1"),
     );
+  });
+
+  test("cellToAxiosParamsDelete returns the correct params", () => {
+    const cell = { row: { original: { id: 17 } } };
+    expect(cellToAxiosParamsDelete(cell)).toEqual({
+      url: "/api/menuitemreview",
+      method: "DELETE",
+      params: { id: 17 },
+    });
+  });
+
+  test("onDeleteSuccess logs and toasts the message", () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    onDeleteSuccess("MenuItemReview deleted");
+    expect(consoleSpy).toHaveBeenCalledWith("MenuItemReview deleted");
+    expect(mockToast).toHaveBeenCalledWith("MenuItemReview deleted");
+    consoleSpy.mockRestore();
   });
 
   test("Delete button calls delete callback", async () => {

--- a/frontend/src/tests/components/Nav/AppNavbar.test.jsx
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.jsx
@@ -193,7 +193,31 @@ describe("AppNavbar tests", () => {
     expect(link.getAttribute("href")).toBe("/restaurants");
   });
 
-  test("Restaurant and UCSBDates links do NOT show when not logged in", async () => {
+  test("renders the MenuItemReview link correctly", async () => {
+    const currentUser = currentUserFixtures.userOnly;
+    const systemInfo = systemInfoFixtures.showingBoth;
+
+    const doLogin = vi.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AppNavbar
+            currentUser={currentUser}
+            systemInfo={systemInfo}
+            doLogin={doLogin}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("MenuItemReview");
+    const link = screen.getByText("MenuItemReview");
+    expect(link).toBeInTheDocument();
+    expect(link.getAttribute("href")).toBe("/menuitemreview");
+  });
+
+  test("Restaurant, UCSBDates, and MenuItemReview links do NOT show when not logged in", async () => {
     const currentUser = null;
     const systemInfo = systemInfoFixtures.showingBoth;
     const doLogin = vi.fn();
@@ -213,6 +237,7 @@ describe("AppNavbar tests", () => {
     expect(screen.queryByText("Restaurants")).not.toBeInTheDocument();
     expect(screen.queryByText("UCSBDates")).not.toBeInTheDocument();
     expect(screen.queryByText("Help Requests")).not.toBeInTheDocument();
+    expect(screen.queryByText("MenuItemReview")).not.toBeInTheDocument();
   });
 
   test("renders the helprequests link correctly", async () => {

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewCreatePage.test.jsx
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewCreatePage.test.jsx
@@ -1,17 +1,40 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import MenuItemReviewCreatePage from "main/pages/MenuItemReview/MenuItemReviewCreatePage";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
-describe("MenuItemReviewCreatePage placeholder tests", () => {
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
+const mockNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    Navigate: vi.fn((x) => {
+      mockNavigate(x);
+      return null;
+    }),
+  };
+});
+
+describe("MenuItemReviewCreatePage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
 
-  const setupUserOnly = () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
     axiosMock.reset();
     axiosMock.resetHistory();
     axiosMock
@@ -20,11 +43,35 @@ describe("MenuItemReviewCreatePage placeholder tests", () => {
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
-  };
+  });
 
   const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    setupUserOnly();
+  test("renders without crashing", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Item Id")).toBeInTheDocument();
+    });
+  });
+
+  test("on submit, makes request to backend, and redirects to /menuitemreview", async () => {
+    const queryClient = new QueryClient();
+    const review = {
+      id: 7,
+      itemId: 1004,
+      reviewerEmail: "reviewer4@ucsb.edu",
+      stars: 5,
+      dateReviewed: "2026-04-23T11:30:00",
+      comments: "Fresh and delicious.",
+    };
+
+    axiosMock.onPost("/api/menuitemreview/post").reply(202, review);
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -34,9 +81,54 @@ describe("MenuItemReviewCreatePage placeholder tests", () => {
       </QueryClientProvider>,
     );
 
-    await screen.findByText("Create page not yet implemented");
-    expect(
-      screen.getByText("Create page not yet implemented"),
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByLabelText("Item Id")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText("Item Id"), {
+      target: { value: "1004" },
+    });
+    fireEvent.change(screen.getByLabelText("Reviewer Email"), {
+      target: { value: "reviewer4@ucsb.edu" },
+    });
+    fireEvent.change(screen.getByLabelText("Stars"), {
+      target: { value: "5" },
+    });
+    fireEvent.change(screen.getByLabelText("Date Reviewed"), {
+      target: { value: "2026-04-23T11:30" },
+    });
+    fireEvent.change(screen.getByLabelText("Comments"), {
+      target: { value: "Fresh and delicious." },
+    });
+    fireEvent.click(screen.getByText("Create"));
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].params).toEqual({
+      itemId: "1004",
+      reviewerEmail: "reviewer4@ucsb.edu",
+      stars: "5",
+      dateReviewed: "2026-04-23T11:30",
+      comments: "Fresh and delicious.",
+    });
+
+    expect(mockToast).toBeCalledWith("New MenuItemReview Created - id: 7");
+    expect(mockNavigate).toBeCalledWith({ to: "/menuitemreview" });
+  });
+
+  test("invalid data does not submit", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByLabelText("Item Id");
+    fireEvent.click(screen.getByText("Create"));
+
+    await screen.findByText(/Item Id is required/);
+    expect(axiosMock.history.post.length).toBe(0);
   });
 });

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewCreatePage.test.jsx
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewCreatePage.test.jsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import MenuItemReviewCreatePage from "main/pages/MenuItemReview/MenuItemReviewCreatePage";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("MenuItemReviewCreatePage placeholder tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    setupUserOnly();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Create page not yet implemented");
+    expect(
+      screen.getByText("Create page not yet implemented"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewEditPage.test.jsx
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewEditPage.test.jsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import MenuItemReviewEditPage from "main/pages/MenuItemReview/MenuItemReviewEditPage";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("MenuItemReviewEditPage placeholder tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    setupUserOnly();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewEditPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Edit page not yet implemented");
+    expect(
+      screen.getByText("Edit page not yet implemented"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewIndexPage.test.jsx
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewIndexPage.test.jsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import MenuItemReviewIndexPage from "main/pages/MenuItemReview/MenuItemReviewIndexPage";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("MenuItemReviewIndexPage placeholder tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    setupUserOnly();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Index page not yet implemented");
+
+    expect(
+      screen.getByText("Index page not yet implemented"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Create")).toHaveAttribute(
+      "href",
+      "/menuitemreview/create",
+    );
+    expect(screen.getByText("Edit")).toHaveAttribute(
+      "href",
+      "/menuitemreview/edit/1",
+    );
+  });
+});

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewIndexPage.test.jsx
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewIndexPage.test.jsx
@@ -1,15 +1,28 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import MenuItemReviewIndexPage from "main/pages/MenuItemReview/MenuItemReviewIndexPage";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
+import mockConsole from "tests/testutils/mockConsole";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
-describe("MenuItemReviewIndexPage placeholder tests", () => {
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
+describe("MenuItemReviewIndexPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
+
+  const testId = "MenuItemReviewTable";
 
   const setupUserOnly = () => {
     axiosMock.reset();
@@ -22,9 +35,22 @@ describe("MenuItemReviewIndexPage placeholder tests", () => {
       .reply(200, systemInfoFixtures.showingNeither);
   };
 
+  const setupAdminUser = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.adminUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
   const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    setupUserOnly();
+
+  test("Renders with Create Button for admin user", async () => {
+    setupAdminUser();
+    axiosMock.onGet("/api/menuitemreview/all").reply(200, []);
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -34,18 +60,125 @@ describe("MenuItemReviewIndexPage placeholder tests", () => {
       </QueryClientProvider>,
     );
 
-    await screen.findByText("Index page not yet implemented");
+    await waitFor(() => {
+      expect(screen.getByText(/Create MenuItemReview/)).toBeInTheDocument();
+    });
+    const button = screen.getByText(/Create MenuItemReview/);
+    expect(button).toHaveAttribute("href", "/menuitemreview/create");
+    expect(button).toHaveAttribute("style", "float: right;");
+  });
+
+  test("renders three reviews correctly for regular user", async () => {
+    setupUserOnly();
+    axiosMock
+      .onGet("/api/menuitemreview/all")
+      .reply(200, menuItemReviewFixtures.threeReviews);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toHaveTextContent("1");
+    });
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent(
+      "3",
+    );
+
+    const createReviewButton = screen.queryByText("Create MenuItemReview");
+    expect(createReviewButton).not.toBeInTheDocument();
+
+    expect(screen.getByText("reviewer2@ucsb.edu")).toBeInTheDocument();
+    expect(
+      screen.getByText("Good option, but it could use more seasoning."),
+    ).toBeInTheDocument();
 
     expect(
-      screen.getByText("Index page not yet implemented"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Create")).toHaveAttribute(
-      "href",
-      "/menuitemreview/create",
+      screen.queryByTestId("MenuItemReviewTable-cell-row-0-col-Delete-button"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("MenuItemReviewTable-cell-row-0-col-Edit-button"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("renders empty table when backend unavailable, user only", async () => {
+    setupUserOnly();
+
+    axiosMock.onGet("/api/menuitemreview/all").timeout();
+
+    const restoreConsole = mockConsole();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
     );
-    expect(screen.getByText("Edit")).toHaveAttribute(
-      "href",
-      "/menuitemreview/edit/1",
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+
+    const errorMessage = console.error.mock.calls[0][0];
+    expect(errorMessage).toMatch(
+      "Error communicating with backend via GET on /api/menuitemreview/all",
     );
+    restoreConsole();
+  });
+
+  test("what happens when you click delete, admin", async () => {
+    setupAdminUser();
+
+    axiosMock
+      .onGet("/api/menuitemreview/all")
+      .reply(200, menuItemReviewFixtures.threeReviews);
+    axiosMock
+      .onDelete("/api/menuitemreview")
+      .reply(200, "MenuItemReview with id 1 was deleted");
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+
+    const deleteButton = await screen.findByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(mockToast).toBeCalledWith("MenuItemReview with id 1 was deleted");
+    });
+
+    await waitFor(() => {
+      expect(axiosMock.history.delete.length).toBe(1);
+    });
+    expect(axiosMock.history.delete[0].url).toBe("/api/menuitemreview");
+    expect(axiosMock.history.delete[0].params).toEqual({ id: 1 });
   });
 });


### PR DESCRIPTION
## Summary
- Replaces the index placeholder with a real `MenuItemReviewIndexPage`.
- Fetches all reviews from `GET /api/menuitemreview/all`.
- Shows create/edit/delete controls for admins and read-only table for ordinary users.
- Adds page tests and Storybook stories.

## Storybook
- Index page story: https://69f15715faec6e353d8ea289-bpekrntzmt.chromatic.com/?path=/story/pages-menuitemreview-menuitemreviewindexpage--empty
- https://69f15715faec6e353d8ea289-bpekrntzmt.chromatic.com/?path=/story/pages-menuitemreview-menuitemreviewindexpage--three-items-ordinary-user
- https://69f15715faec6e353d8ea289-bpekrntzmt.chromatic.com/?path=/story/pages-menuitemreview-menuitemreviewindexpage--three-items-admin-user

## Screenshot
<img width="1183" height="595" alt="image" src="https://github.com/user-attachments/assets/ea23a3ee-fc65-40d6-844c-4280f18d85a9" />
<img width="1192" height="587" alt="image" src="https://github.com/user-attachments/assets/881437ac-9628-4a6d-b919-2a891ddb55b8" />
<img width="1183" height="557" alt="image" src="https://github.com/user-attachments/assets/9781d4d0-53c9-4341-8d5a-8b1a2462b359" />


## Testing
- `npm --prefix frontend test`
- `npm --prefix frontend run lint`

Closes #35

