### PR TITLE
rs - Implement HelpRequest Index page with tests and stories

### DIFF
--- a/frontend/src/main/pages/HelpRequests/HelpRequestCreatePage.jsx
+++ b/frontend/src/main/pages/HelpRequests/HelpRequestCreatePage.jsx
@@ -1,11 +1,51 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import HelpRequestForm from "main/components/HelpRequests/HelpRequestForm";
+import { Navigate } from "react-router";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function HelpRequestCreatePage() {
-  // Stryker disable all : placeholder for future implementation
+export default function HelpRequestCreatePage({ storybook = false }) {
+  const objectToAxiosParams = (helpRequest) => ({
+    url: "/api/helprequests/post",
+    method: "POST",
+    params: {
+      requesterEmail: helpRequest.requesterEmail,
+      teamId: helpRequest.teamId,
+      tableOrBreakoutRoom: helpRequest.tableOrBreakoutRoom,
+      requestTime: helpRequest.requestTime,
+      explanation: helpRequest.explanation,
+      solved: helpRequest.solved,
+    },
+  });
+
+  const onSuccess = (helpRequest) => {
+    toast(
+      `New HelpRequest Created - id: ${helpRequest.id} requesterEmail: ${helpRequest.requesterEmail}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    ["/api/helprequests/all"],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/helprequests" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create New HelpRequest</h1>
+        <HelpRequestForm submitAction={onSubmit} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/HelpRequests/HelpRequestIndexPage.jsx
+++ b/frontend/src/main/pages/HelpRequests/HelpRequestIndexPage.jsx
@@ -1,17 +1,49 @@
+import React from "react";
+import { useBackend } from "main/utils/useBackend";
+
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import HelpRequestTable from "main/components/HelpRequests/HelpRequestTable";
+import { useCurrentUser, hasRole } from "main/utils/useCurrentUser";
+import { Button } from "react-bootstrap";
 
 export default function HelpRequestIndexPage() {
-  // Stryker disable all : placeholder for future implementation
+  const currentUser = useCurrentUser();
+
+  const {
+    data: helpRequests,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/helprequests/all"],
+    { method: "GET", url: "/api/helprequests/all" },
+    // Stryker disable next-line all : don't test default value of empty list
+    [],
+  );
+
+  const createButton = () => {
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+      return (
+        <Button
+          variant="primary"
+          href="/helprequests/create"
+          style={{ float: "right" }}
+        >
+          Create HelpRequest
+        </Button>
+      );
+    }
+  };
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Index page not yet implemented</h1>
-        <p>
-          <a href="/helprequests/create">Create</a>
-        </p>
-        <p>
-          <a href="/helprequests/edit/1">Edit</a>
-        </p>
+        {createButton()}
+        <h1>Help Requests</h1>
+        <HelpRequestTable
+          helpRequests={helpRequests}
+          currentUser={currentUser}
+        />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/HelpRequests/HelpRequestCreatePage.stories.jsx
+++ b/frontend/src/stories/pages/HelpRequests/HelpRequestCreatePage.stories.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import HelpRequestCreatePage from "main/pages/HelpRequests/HelpRequestCreatePage";
+
+export default {
+  title: "pages/HelpRequests/HelpRequestCreatePage",
+  component: HelpRequestCreatePage,
+};
+
+const Template = () => <HelpRequestCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.post("/api/helprequests/post", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/stories/pages/HelpRequests/HelpRequestIndexPage.stories.jsx
+++ b/frontend/src/stories/pages/HelpRequests/HelpRequestIndexPage.stories.jsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
+import { http, HttpResponse } from "msw";
+
+import HelpRequestIndexPage from "main/pages/HelpRequests/HelpRequestIndexPage";
+
+export default {
+  title: "pages/HelpRequests/HelpRequestIndexPage",
+  component: HelpRequestIndexPage,
+};
+
+const Template = () => <HelpRequestIndexPage storybook={true} />;
+
+export const Empty = Template.bind({});
+Empty.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/helprequests/all", () => {
+      return HttpResponse.json([], { status: 200 });
+    }),
+  ],
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+ThreeItemsOrdinaryUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/helprequests/all", () => {
+      return HttpResponse.json(helpRequestFixtures.threeHelpRequests);
+    }),
+  ],
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.adminUser);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/helprequests/all", () => {
+      return HttpResponse.json(helpRequestFixtures.threeHelpRequests);
+    }),
+    http.delete("/api/helprequests", () => {
+      return HttpResponse.json(
+        { message: "HelpRequest deleted successfully" },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/HelpRequests/HelpRequestCreatePage.test.jsx
+++ b/frontend/src/tests/pages/HelpRequests/HelpRequestCreatePage.test.jsx
@@ -1,21 +1,49 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import HelpRequestCreatePage from "main/pages/HelpRequests/HelpRequestCreatePage";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
-import HelpRequestCreatePage from "main/pages/HelpRequests/HelpRequestCreatePage";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
+const mockNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    Navigate: vi.fn((x) => {
+      mockNavigate(x);
+      return null;
+    }),
+  };
+});
+
 describe("HelpRequestCreatePage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
-  axiosMock
-    .onGet("/api/currentUser")
-    .reply(200, apiCurrentUserFixtures.userOnly);
-  axiosMock
-    .onGet("/api/systemInfo")
-    .reply(200, systemInfoFixtures.showingNeither);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  });
 
   const queryClient = new QueryClient();
   test("renders without crashing", async () => {
@@ -27,8 +55,75 @@ describe("HelpRequestCreatePage tests", () => {
       </QueryClientProvider>,
     );
 
-    expect(
-      await screen.findByText("Create page not yet implemented"),
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByLabelText("Requester Email")).toBeInTheDocument();
+    });
+  });
+
+  test("on submit, makes request to backend, and redirects to /helprequests", async () => {
+    const queryClient = new QueryClient();
+    const helpRequest = {
+      id: 1,
+      requesterEmail: "cgaucho@ucsb.edu",
+      teamId: "s22-5pm-3",
+      tableOrBreakoutRoom: "7",
+      requestTime: "2022-04-20T17:35:00",
+      explanation: "Need help with Swagger-ui",
+      solved: true,
+    };
+
+    axiosMock.onPost("/api/helprequests/post").reply(202, helpRequest);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Requester Email")).toBeInTheDocument();
+    });
+
+    const requesterEmailInput = screen.getByLabelText("Requester Email");
+    const teamIdInput = screen.getByLabelText("Team Id");
+    const tableOrBreakoutRoomInput = screen.getByLabelText(
+      "Table or Breakout Room",
+    );
+    const requestTimeInput = screen.getByLabelText("Request Time (ISO format)");
+    const explanationInput = screen.getByLabelText("Explanation");
+    const solvedInput = screen.getByLabelText("Solved");
+    const createButton = screen.getByText("Create");
+
+    fireEvent.change(requesterEmailInput, {
+      target: { value: "cgaucho@ucsb.edu" },
+    });
+    fireEvent.change(teamIdInput, { target: { value: "s22-5pm-3" } });
+    fireEvent.change(tableOrBreakoutRoomInput, { target: { value: "7" } });
+    fireEvent.change(requestTimeInput, {
+      target: { value: "2022-04-20T17:35" },
+    });
+    fireEvent.change(explanationInput, {
+      target: { value: "Need help with Swagger-ui" },
+    });
+    fireEvent.click(solvedInput);
+    fireEvent.click(createButton);
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].params).toEqual({
+      requesterEmail: "cgaucho@ucsb.edu",
+      teamId: "s22-5pm-3",
+      tableOrBreakoutRoom: "7",
+      requestTime: "2022-04-20T17:35",
+      explanation: "Need help with Swagger-ui",
+      solved: true,
+    });
+
+    expect(mockToast).toBeCalledWith(
+      "New HelpRequest Created - id: 1 requesterEmail: cgaucho@ucsb.edu",
+    );
+    expect(mockNavigate).toBeCalledWith({ to: "/helprequests" });
   });
 });

--- a/frontend/src/tests/pages/HelpRequests/HelpRequestIndexPage.test.jsx
+++ b/frontend/src/tests/pages/HelpRequests/HelpRequestIndexPage.test.jsx
@@ -1,24 +1,57 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import HelpRequestIndexPage from "main/pages/HelpRequests/HelpRequestIndexPage";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
-import HelpRequestIndexPage from "main/pages/HelpRequests/HelpRequestIndexPage";
+import mockConsole from "tests/testutils/mockConsole";
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
 describe("HelpRequestIndexPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
-  axiosMock
-    .onGet("/api/currentUser")
-    .reply(200, apiCurrentUserFixtures.userOnly);
-  axiosMock
-    .onGet("/api/systemInfo")
-    .reply(200, systemInfoFixtures.showingNeither);
+
+  const testId = "HelpRequestTable";
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const setupAdminUser = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.adminUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
 
   const queryClient = new QueryClient();
-  test("renders without crashing", async () => {
+
+  test("Renders with Create Button for admin user", async () => {
+    setupAdminUser();
+    axiosMock.onGet("/api/helprequests/all").reply(200, []);
+
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -27,8 +60,126 @@ describe("HelpRequestIndexPage tests", () => {
       </QueryClientProvider>,
     );
 
+    await waitFor(() => {
+      expect(screen.getByText(/Create HelpRequest/)).toBeInTheDocument();
+    });
+    const button = screen.getByText(/Create HelpRequest/);
+    expect(button).toHaveAttribute("href", "/helprequests/create");
+    expect(button).toHaveAttribute("style", "float: right;");
+  });
+
+  test("renders three help requests correctly for regular user", async () => {
+    setupUserOnly();
+    axiosMock
+      .onGet("/api/helprequests/all")
+      .reply(200, helpRequestFixtures.threeHelpRequests);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toHaveTextContent("1");
+    });
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent(
+      "3",
+    );
+
+    const createHelpRequestButton = screen.queryByText("Create HelpRequest");
+    expect(createHelpRequestButton).not.toBeInTheDocument();
+
+    const email = screen.getByText("cgaucho@ucsb.edu");
+    expect(email).toBeInTheDocument();
+
+    const explanation = screen.getByText("Need help with Swagger-ui");
+    expect(explanation).toBeInTheDocument();
+
     expect(
-      await screen.findByText("Index page not yet implemented"),
-    ).toBeInTheDocument();
+      screen.queryByTestId("HelpRequestTable-cell-row-0-col-Delete-button"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("HelpRequestTable-cell-row-0-col-Edit-button"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("renders empty table when backend unavailable, user only", async () => {
+    setupUserOnly();
+
+    axiosMock.onGet("/api/helprequests/all").timeout();
+
+    const restoreConsole = mockConsole();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+
+    const errorMessage = console.error.mock.calls[0][0];
+    expect(errorMessage).toMatch(
+      "Error communicating with backend via GET on /api/helprequests/all",
+    );
+    restoreConsole();
+  });
+
+  test("what happens when you click delete, admin", async () => {
+    setupAdminUser();
+
+    axiosMock
+      .onGet("/api/helprequests/all")
+      .reply(200, helpRequestFixtures.threeHelpRequests);
+    axiosMock
+      .onDelete("/api/helprequests")
+      .reply(200, "HelpRequest with id 1 was deleted");
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+
+    const deleteButton = await screen.findByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(mockToast).toBeCalledWith("HelpRequest with id 1 was deleted");
+    });
+
+    await waitFor(() => {
+      expect(axiosMock.history.delete.length).toBe(1);
+    });
+    expect(axiosMock.history.delete[0].url).toBe("/api/helprequests");
+    expect(axiosMock.history.delete[0].params).toEqual({ id: 1 });
   });
 });


### PR DESCRIPTION
Replaced placeholder with full Index page showing all help requests in a table. Admin users see Create button, Edit/Delete buttons. Includes 4 tests and 3 Storybook stories.

Closes #44

https://69f15715faec6e353d8ea289-orxgrnrmvw.chromatic.com/?path=/story/pages-helprequests-helprequestindexpage--three-items-admin-user

<img width="1700" height="561" alt="image" src="https://github.com/user-attachments/assets/269335cb-287e-445e-8b39-be7f49ccc7b3" />
