### PR TITLE
rs - Implement HelpRequest Edit page with tests and stories

### DIFF
--- a/frontend/src/main/pages/HelpRequests/HelpRequestEditPage.jsx
+++ b/frontend/src/main/pages/HelpRequests/HelpRequestEditPage.jsx
@@ -1,11 +1,80 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router";
+import HelpRequestForm from "main/components/HelpRequests/HelpRequestForm";
+import { Navigate } from "react-router";
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function HelpRequestEditPage() {
-  // Stryker disable all : placeholder for future implementation
+export default function HelpRequestEditPage({ storybook = false }) {
+  let { id } = useParams();
+
+  const {
+    data: helpRequest,
+    _error,
+    _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    [`/api/helprequests?id=${id}`],
+    {
+      // Stryker disable next-line all : GET is the default, so mutating this to "" doesn't introduce a bug
+      method: "GET",
+      url: `/api/helprequests`,
+      params: {
+        id,
+      },
+    },
+  );
+
+  const objectToAxiosPutParams = (helpRequest) => ({
+    url: "/api/helprequests",
+    method: "PUT",
+    params: {
+      id: helpRequest.id,
+    },
+    data: {
+      requesterEmail: helpRequest.requesterEmail,
+      teamId: helpRequest.teamId,
+      tableOrBreakoutRoom: helpRequest.tableOrBreakoutRoom,
+      requestTime: helpRequest.requestTime,
+      explanation: helpRequest.explanation,
+      solved: helpRequest.solved,
+    },
+  });
+
+  const onSuccess = (helpRequest) => {
+    toast(
+      `HelpRequest Updated - id: ${helpRequest.id} requesterEmail: ${helpRequest.requesterEmail}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/helprequests?id=${id}`],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/helprequests" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Edit page not yet implemented</h1>
+        <h1>Edit HelpRequest</h1>
+        {helpRequest && (
+          <HelpRequestForm
+            submitAction={onSubmit}
+            buttonLabel={"Update"}
+            initialContents={helpRequest}
+          />
+        )}
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/HelpRequests/HelpRequestEditPage.stories.jsx
+++ b/frontend/src/stories/pages/HelpRequests/HelpRequestEditPage.stories.jsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import HelpRequestEditPage from "main/pages/HelpRequests/HelpRequestEditPage";
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
+
+export default {
+  title: "pages/HelpRequests/HelpRequestEditPage",
+  component: HelpRequestEditPage,
+};
+
+const Template = () => <HelpRequestEditPage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/helprequests", () => {
+      return HttpResponse.json(helpRequestFixtures.threeHelpRequests[0], {
+        status: 200,
+      });
+    }),
+    http.put("/api/helprequests", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/HelpRequests/HelpRequestEditPage.test.jsx
+++ b/frontend/src/tests/pages/HelpRequests/HelpRequestEditPage.test.jsx
@@ -165,6 +165,11 @@ describe("HelpRequestEditPage tests", () => {
 
       expect(axiosMock.history.put.length).toBe(1);
       expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+      expect(JSON.parse(axiosMock.history.put[0].data)).toMatchObject({
+        requesterEmail: "ldelplaya@ucsb.edu",
+        teamId: "s22-6pm-3",
+        explanation: "Dokku problems",
+      });
     });
 
     test("Changes when you click Update", async () => {

--- a/frontend/src/tests/pages/HelpRequests/HelpRequestEditPage.test.jsx
+++ b/frontend/src/tests/pages/HelpRequests/HelpRequestEditPage.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
 import HelpRequestEditPage from "main/pages/HelpRequests/HelpRequestEditPage";
@@ -7,28 +7,204 @@ import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "tests/testutils/mockConsole";
 
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
+const mockNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    useParams: vi.fn(() => ({
+      id: 17,
+    })),
+    Navigate: vi.fn((x) => {
+      mockNavigate(x);
+      return null;
+    }),
+  };
+});
+
+let axiosMock;
 describe("HelpRequestEditPage tests", () => {
-  const axiosMock = new AxiosMockAdapter(axios);
-  axiosMock
-    .onGet("/api/currentUser")
-    .reply(200, apiCurrentUserFixtures.userOnly);
-  axiosMock
-    .onGet("/api/systemInfo")
-    .reply(200, systemInfoFixtures.showingNeither);
+  describe("when the backend doesn't return data", () => {
+    beforeEach(() => {
+      axiosMock = new AxiosMockAdapter(axios);
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock.onGet("/api/helprequests", { params: { id: 17 } }).timeout();
+    });
 
-  const queryClient = new QueryClient();
-  test("renders without crashing", async () => {
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <HelpRequestEditPage />
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
+    afterEach(() => {
+      mockToast.mockClear();
+      mockNavigate.mockClear();
+      axiosMock.restore();
+      axiosMock.resetHistory();
+    });
 
-    expect(
-      await screen.findByText("Edit page not yet implemented"),
-    ).toBeInTheDocument();
+    const queryClient = new QueryClient();
+    test("renders header but form is not present", async () => {
+      const restoreConsole = mockConsole();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <HelpRequestEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+      await screen.findByText("Edit HelpRequest");
+      expect(
+        screen.queryByTestId("HelpRequestForm-requesterEmail"),
+      ).not.toBeInTheDocument();
+      restoreConsole();
+    });
+  });
+
+  describe("tests where backend is working normally", () => {
+    beforeEach(() => {
+      axiosMock = new AxiosMockAdapter(axios);
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock.onGet("/api/helprequests", { params: { id: 17 } }).reply(200, {
+        id: 17,
+        requesterEmail: "cgaucho@ucsb.edu",
+        teamId: "s22-5pm-3",
+        tableOrBreakoutRoom: "7",
+        requestTime: "2022-04-20T17:35:00",
+        explanation: "Need help with Swagger-ui",
+        solved: false,
+      });
+      axiosMock.onPut("/api/helprequests").reply(200, {
+        id: "17",
+        requesterEmail: "ldelplaya@ucsb.edu",
+        teamId: "s22-6pm-3",
+        tableOrBreakoutRoom: "11",
+        requestTime: "2022-04-21T10:00:00",
+        explanation: "Dokku problems",
+        solved: true,
+      });
+    });
+
+    afterEach(() => {
+      mockToast.mockClear();
+      mockNavigate.mockClear();
+      axiosMock.restore();
+      axiosMock.resetHistory();
+    });
+
+    const queryClient = new QueryClient();
+
+    test("Is populated with the data provided", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <HelpRequestEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("HelpRequestForm-id");
+
+      const idField = screen.getByTestId("HelpRequestForm-id");
+      const requesterEmailField = screen.getByTestId(
+        "HelpRequestForm-requesterEmail",
+      );
+      const teamIdField = screen.getByTestId("HelpRequestForm-teamId");
+      const explanationField = screen.getByTestId(
+        "HelpRequestForm-explanation",
+      );
+      const submitButton = screen.getByTestId("HelpRequestForm-submit");
+
+      expect(idField).toBeInTheDocument();
+      expect(idField).toHaveValue("17");
+      expect(requesterEmailField).toBeInTheDocument();
+      expect(requesterEmailField).toHaveValue("cgaucho@ucsb.edu");
+      expect(teamIdField).toBeInTheDocument();
+      expect(teamIdField).toHaveValue("s22-5pm-3");
+      expect(explanationField).toBeInTheDocument();
+      expect(explanationField).toHaveValue("Need help with Swagger-ui");
+
+      expect(submitButton).toHaveTextContent("Update");
+
+      fireEvent.change(requesterEmailField, {
+        target: { value: "ldelplaya@ucsb.edu" },
+      });
+      fireEvent.change(teamIdField, { target: { value: "s22-6pm-3" } });
+      fireEvent.change(explanationField, {
+        target: { value: "Dokku problems" },
+      });
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(mockToast).toBeCalled());
+      expect(mockToast).toBeCalledWith(
+        "HelpRequest Updated - id: 17 requesterEmail: ldelplaya@ucsb.edu",
+      );
+
+      expect(mockNavigate).toBeCalledWith({ to: "/helprequests" });
+
+      expect(axiosMock.history.put.length).toBe(1);
+      expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+    });
+
+    test("Changes when you click Update", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <HelpRequestEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("HelpRequestForm-id");
+
+      const idField = screen.getByTestId("HelpRequestForm-id");
+      const requesterEmailField = screen.getByTestId(
+        "HelpRequestForm-requesterEmail",
+      );
+      const explanationField = screen.getByTestId(
+        "HelpRequestForm-explanation",
+      );
+      const submitButton = screen.getByTestId("HelpRequestForm-submit");
+
+      expect(idField).toHaveValue("17");
+      expect(requesterEmailField).toHaveValue("cgaucho@ucsb.edu");
+      expect(submitButton).toBeInTheDocument();
+
+      fireEvent.change(requesterEmailField, {
+        target: { value: "ldelplaya@ucsb.edu" },
+      });
+      fireEvent.change(explanationField, {
+        target: { value: "Dokku problems" },
+      });
+
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(mockToast).toBeCalled());
+      expect(mockToast).toBeCalledWith(
+        "HelpRequest Updated - id: 17 requesterEmail: ldelplaya@ucsb.edu",
+      );
+      expect(mockNavigate).toBeCalledWith({ to: "/helprequests" });
+    });
   });
 });


### PR DESCRIPTION
Replaced placeholder with full Edit page. Fetches existing record by id, populates form, submits PUT request, shows toast, and redirects to /helprequests. Includes 3 tests and Storybook story.

Closes #45

https://69f15715faec6e353d8ea289-jazcbcgfer.chromatic.com/?path=/story/pages-helprequests-helprequesteditpage--default

<img width="2099" height="1084" alt="image" src="https://github.com/user-attachments/assets/5440d877-5edc-4ee3-a584-5e2ee233be19" />
