### PR TITLE
Add RecommendationRequest form component

### DIFF
--- a/frontend/src/fixtures/recommendationRequestFixtures.js
+++ b/frontend/src/fixtures/recommendationRequestFixtures.js
@@ -1,0 +1,42 @@
+const recommendationRequestFixtures = {
+  oneRecommendationRequest: {
+    id: 1,
+    requesterEmail: "student@ucsb.edu",
+    professorEmail: "professor@ucsb.edu",
+    explanation: "Requesting a recommendation for graduate school.",
+    dateRequested: "2026-04-15T10:30:00",
+    dateNeeded: "2026-05-01T17:00:00",
+    done: false,
+  },
+  threeRecommendationRequests: [
+    {
+      id: 1,
+      requesterEmail: "student1@ucsb.edu",
+      professorEmail: "professor1@ucsb.edu",
+      explanation: "Requesting a recommendation for graduate school.",
+      dateRequested: "2026-04-15T10:30:00",
+      dateNeeded: "2026-05-01T17:00:00",
+      done: false,
+    },
+    {
+      id: 2,
+      requesterEmail: "student2@ucsb.edu",
+      professorEmail: "professor2@ucsb.edu",
+      explanation: "Requesting a recommendation for a summer internship.",
+      dateRequested: "2026-04-16T09:00:00",
+      dateNeeded: "2026-05-10T12:00:00",
+      done: true,
+    },
+    {
+      id: 3,
+      requesterEmail: "student3@ucsb.edu",
+      professorEmail: "professor3@ucsb.edu",
+      explanation: "Requesting a recommendation for a scholarship application.",
+      dateRequested: "2026-04-20T14:15:00",
+      dateNeeded: "2026-05-15T23:59:00",
+      done: false,
+    },
+  ],
+};
+
+export { recommendationRequestFixtures };

--- a/frontend/src/main/components/RecommendationRequest/RecommendationRequestForm.jsx
+++ b/frontend/src/main/components/RecommendationRequest/RecommendationRequestForm.jsx
@@ -1,0 +1,154 @@
+import { Button, Form } from "react-bootstrap";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router";
+
+function RecommendationRequestForm({
+  initialContents,
+  submitAction,
+  buttonLabel = "Create",
+}) {
+  // Stryker disable all
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm({ defaultValues: initialContents || {} });
+  // Stryker restore all
+
+  const navigate = useNavigate();
+  const testIdPrefix = "RecommendationRequestForm";
+
+  // Stryker disable Regex
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/i;
+  // Stryker restore Regex
+
+  return (
+    <Form onSubmit={handleSubmit(submitAction)}>
+      {initialContents && (
+        <Form.Group className="mb-3">
+          <Form.Label htmlFor="id">Id</Form.Label>
+          <Form.Control
+            data-testid={`${testIdPrefix}-id`}
+            id="id"
+            type="text"
+            {...register("id")}
+            value={initialContents.id}
+            disabled
+          />
+        </Form.Group>
+      )}
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="requesterEmail">Requester Email</Form.Label>
+        <Form.Control
+          data-testid={`${testIdPrefix}-requesterEmail`}
+          id="requesterEmail"
+          type="email"
+          isInvalid={Boolean(errors.requesterEmail)}
+          {...register("requesterEmail", {
+            required: "Requester Email is required.",
+            pattern: {
+              value: emailRegex,
+              message: "Requester Email must be a valid email address.",
+            },
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.requesterEmail?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="professorEmail">Professor Email</Form.Label>
+        <Form.Control
+          data-testid={`${testIdPrefix}-professorEmail`}
+          id="professorEmail"
+          type="email"
+          isInvalid={Boolean(errors.professorEmail)}
+          {...register("professorEmail", {
+            required: "Professor Email is required.",
+            pattern: {
+              value: emailRegex,
+              message: "Professor Email must be a valid email address.",
+            },
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.professorEmail?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="explanation">Explanation</Form.Label>
+        <Form.Control
+          data-testid={`${testIdPrefix}-explanation`}
+          id="explanation"
+          as="textarea"
+          rows={3}
+          isInvalid={Boolean(errors.explanation)}
+          {...register("explanation", {
+            required: "Explanation is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.explanation?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="dateRequested">Date Requested</Form.Label>
+        <Form.Control
+          data-testid={`${testIdPrefix}-dateRequested`}
+          id="dateRequested"
+          type="datetime-local"
+          isInvalid={Boolean(errors.dateRequested)}
+          {...register("dateRequested", {
+            required: "Date Requested is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.dateRequested?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="dateNeeded">Date Needed</Form.Label>
+        <Form.Control
+          data-testid={`${testIdPrefix}-dateNeeded`}
+          id="dateNeeded"
+          type="datetime-local"
+          isInvalid={Boolean(errors.dateNeeded)}
+          {...register("dateNeeded", {
+            required: "Date Needed is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.dateNeeded?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="done">Done</Form.Label>
+        <Form.Check
+          data-testid={`${testIdPrefix}-done`}
+          id="done"
+          type="checkbox"
+          {...register("done")}
+        />
+      </Form.Group>
+
+      <Button type="submit" data-testid={`${testIdPrefix}-submit`}>
+        {buttonLabel}
+      </Button>
+      <Button
+        variant="Secondary"
+        onClick={() => navigate(-1)}
+        data-testid={`${testIdPrefix}-cancel`}
+      >
+        Cancel
+      </Button>
+    </Form>
+  );
+}
+
+export default RecommendationRequestForm;

--- a/frontend/src/stories/components/RecommendationRequest/RecommendationRequestForm.stories.jsx
+++ b/frontend/src/stories/components/RecommendationRequest/RecommendationRequestForm.stories.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import RecommendationRequestForm from "main/components/RecommendationRequest/RecommendationRequestForm";
+import { recommendationRequestFixtures } from "fixtures/recommendationRequestFixtures";
+
+export default {
+  title: "components/RecommendationRequest/RecommendationRequestForm",
+  component: RecommendationRequestForm,
+};
+
+const Template = (args) => {
+  return <RecommendationRequestForm {...args} />;
+};
+
+export const Create = Template.bind({});
+
+Create.args = {
+  buttonLabel: "Create",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};
+
+export const Update = Template.bind({});
+
+Update.args = {
+  initialContents: recommendationRequestFixtures.oneRecommendationRequest,
+  buttonLabel: "Update",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};

--- a/frontend/src/tests/components/RecommendationRequest/RecommendationRequestForm.test.jsx
+++ b/frontend/src/tests/components/RecommendationRequest/RecommendationRequestForm.test.jsx
@@ -1,0 +1,152 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router";
+
+import RecommendationRequestForm from "main/components/RecommendationRequest/RecommendationRequestForm";
+import { recommendationRequestFixtures } from "fixtures/recommendationRequestFixtures";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const mockedNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const originalModule = await vi.importActual("react-router");
+  return {
+    ...originalModule,
+    useNavigate: () => mockedNavigate,
+  };
+});
+
+describe("RecommendationRequestForm tests", () => {
+  const queryClient = new QueryClient();
+
+  const expectedHeaders = [
+    "Requester Email",
+    "Professor Email",
+    "Explanation",
+    "Date Requested",
+    "Date Needed",
+    "Done",
+  ];
+  const testId = "RecommendationRequestForm";
+
+  test("renders correctly with no initialContents", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <RecommendationRequestForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId(`${testId}-id`)).not.toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-requesterEmail`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-professorEmail`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-explanation`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-dateRequested`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-dateNeeded`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-done`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-submit`)).toBeInTheDocument();
+  });
+
+  test("renders correctly when passing in initialContents", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <RecommendationRequestForm
+            initialContents={
+              recommendationRequestFixtures.oneRecommendationRequest
+            }
+          />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(await screen.findByTestId(`${testId}-id`)).toBeInTheDocument();
+    expect(screen.getByText("Id")).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-id`)).toHaveValue("1");
+    expect(screen.getByTestId(`${testId}-requesterEmail`)).toHaveValue(
+      "student@ucsb.edu",
+    );
+    expect(screen.getByTestId(`${testId}-professorEmail`)).toHaveValue(
+      "professor@ucsb.edu",
+    );
+    expect(screen.getByTestId(`${testId}-explanation`)).toHaveValue(
+      "Requesting a recommendation for graduate school.",
+    );
+    expect(screen.getByTestId(`${testId}-dateRequested`)).toHaveValue(
+      "2026-04-15T10:30",
+    );
+    expect(screen.getByTestId(`${testId}-dateNeeded`)).toHaveValue(
+      "2026-05-01T17:00",
+    );
+    expect(screen.getByTestId(`${testId}-done`)).not.toBeChecked();
+  });
+
+  test("that navigate(-1) is called when Cancel is clicked", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <RecommendationRequestForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+    expect(await screen.findByTestId(`${testId}-cancel`)).toBeInTheDocument();
+    const cancelButton = screen.getByTestId(`${testId}-cancel`);
+
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+  });
+
+  test("that the correct validations are performed", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <RecommendationRequestForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+    const submitButton = screen.getByTestId(`${testId}-submit`);
+    fireEvent.click(submitButton);
+
+    expect(
+      await screen.findByText(/Requester Email is required/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Professor Email is required/)).toBeInTheDocument();
+    expect(screen.getByText(/Explanation is required/)).toBeInTheDocument();
+    expect(screen.getByText(/Date Requested is required/)).toBeInTheDocument();
+    expect(screen.getByText(/Date Needed is required/)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId(`${testId}-requesterEmail`), {
+      target: { value: "not-an-email" },
+    });
+    fireEvent.change(screen.getByTestId(`${testId}-professorEmail`), {
+      target: { value: "also-not-an-email" },
+    });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Requester Email must be a valid email address/),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/Professor Email must be a valid email address/),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Merge after PR #94.

This PR adds a RecommendationRequest form so users can enter and update recommendation request data in the frontend.

Closes #22

## Summary
- Adds RecommendationRequestForm with requester/professor email, explanation, requested/needed dates, and done fields.
- Adds form tests covering create mode, update mode, validation, and cancel navigation.
- Adds Storybook stories for create and update scenarios.

## Testing
- Ran npm test from frontend with Node 22.22.2
- Verified 46 test files and 164 tests pass with 100% coverage

## Storybook
- Story: components/RecommendationRequest/RecommendationRequestForm
- Stories: Create, Update