### PR TITLE
Add RecommendationRequest table component

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -19,6 +19,10 @@ import PlaceholderIndexPage from "main/pages/Placeholder/PlaceholderIndexPage";
 import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage";
 import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
 
+import RecommendationRequestIndexPage from "main/pages/RecommendationRequest/RecommendationRequestIndexPage";
+import RecommendationRequestCreatePage from "main/pages/RecommendationRequest/RecommendationRequestCreatePage";
+import RecommendationRequestEditPage from "main/pages/RecommendationRequest/RecommendationRequestEditPage";
+
 import ArticlesIndexPage from "main/pages/Articles/ArticlesIndexPage";
 import ArticlesCreatePage from "main/pages/Articles/ArticlesCreatePage";
 import ArticlesEditPage from "main/pages/Articles/ArticlesEditPage";
@@ -105,6 +109,11 @@ function App() {
       {hasRole(currentUser, "ROLE_USER") && (
         <>
           <Route exact path="/placeholder" element={<PlaceholderIndexPage />} />
+          <Route
+            exact
+            path="/recommendationrequest"
+            element={<RecommendationRequestIndexPage />}
+          />
         </>
       )}
       {hasRole(currentUser, "ROLE_ADMIN") && (
@@ -118,6 +127,16 @@ function App() {
             exact
             path="/placeholder/create"
             element={<PlaceholderCreatePage />}
+          />
+          <Route
+            exact
+            path="/recommendationrequest/edit/:id"
+            element={<RecommendationRequestEditPage />}
+          />
+          <Route
+            exact
+            path="/recommendationrequest/create"
+            element={<RecommendationRequestCreatePage />}
           />
         </>
       )}

--- a/frontend/src/fixtures/recommendationRequestFixtures.js
+++ b/frontend/src/fixtures/recommendationRequestFixtures.js
@@ -1,0 +1,42 @@
+const recommendationRequestFixtures = {
+  oneRecommendationRequest: {
+    id: 1,
+    requesterEmail: "student@ucsb.edu",
+    professorEmail: "professor@ucsb.edu",
+    explanation: "Requesting a recommendation for graduate school.",
+    dateRequested: "2026-04-15T10:30:00",
+    dateNeeded: "2026-05-01T17:00:00",
+    done: false,
+  },
+  threeRecommendationRequests: [
+    {
+      id: 1,
+      requesterEmail: "student1@ucsb.edu",
+      professorEmail: "professor1@ucsb.edu",
+      explanation: "Requesting a recommendation for graduate school.",
+      dateRequested: "2026-04-15T10:30:00",
+      dateNeeded: "2026-05-01T17:00:00",
+      done: false,
+    },
+    {
+      id: 2,
+      requesterEmail: "student2@ucsb.edu",
+      professorEmail: "professor2@ucsb.edu",
+      explanation: "Requesting a recommendation for a summer internship.",
+      dateRequested: "2026-04-16T09:00:00",
+      dateNeeded: "2026-05-10T12:00:00",
+      done: true,
+    },
+    {
+      id: 3,
+      requesterEmail: "student3@ucsb.edu",
+      professorEmail: "professor3@ucsb.edu",
+      explanation: "Requesting a recommendation for a scholarship application.",
+      dateRequested: "2026-04-20T14:15:00",
+      dateNeeded: "2026-05-15T23:59:00",
+      done: false,
+    },
+  ],
+};
+
+export { recommendationRequestFixtures };

--- a/frontend/src/main/components/Nav/AppNavbar.jsx
+++ b/frontend/src/main/components/Nav/AppNavbar.jsx
@@ -77,6 +77,9 @@ export default function AppNavbar({
                   <Nav.Link as={Link} to="/placeholder">
                     Placeholder
                   </Nav.Link>
+                  <Nav.Link as={Link} to="/recommendationrequest">
+                    RecommendationRequest
+                  </Nav.Link>
                   <Nav.Link as={Link} to="/helprequests">
                     Help Requests
                   </Nav.Link>

--- a/frontend/src/main/components/RecommendationRequest/RecommendationRequestForm.jsx
+++ b/frontend/src/main/components/RecommendationRequest/RecommendationRequestForm.jsx
@@ -1,0 +1,154 @@
+import { Button, Form } from "react-bootstrap";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router";
+
+function RecommendationRequestForm({
+  initialContents,
+  submitAction,
+  buttonLabel = "Create",
+}) {
+  // Stryker disable all
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm({ defaultValues: initialContents || {} });
+  // Stryker restore all
+
+  const navigate = useNavigate();
+  const testIdPrefix = "RecommendationRequestForm";
+
+  // Stryker disable Regex
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/i;
+  // Stryker restore Regex
+
+  return (
+    <Form onSubmit={handleSubmit(submitAction)}>
+      {initialContents && (
+        <Form.Group className="mb-3">
+          <Form.Label htmlFor="id">Id</Form.Label>
+          <Form.Control
+            data-testid={`${testIdPrefix}-id`}
+            id="id"
+            type="text"
+            {...register("id")}
+            value={initialContents.id}
+            disabled
+          />
+        </Form.Group>
+      )}
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="requesterEmail">Requester Email</Form.Label>
+        <Form.Control
+          data-testid={`${testIdPrefix}-requesterEmail`}
+          id="requesterEmail"
+          type="email"
+          isInvalid={Boolean(errors.requesterEmail)}
+          {...register("requesterEmail", {
+            required: "Requester Email is required.",
+            pattern: {
+              value: emailRegex,
+              message: "Requester Email must be a valid email address.",
+            },
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.requesterEmail?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="professorEmail">Professor Email</Form.Label>
+        <Form.Control
+          data-testid={`${testIdPrefix}-professorEmail`}
+          id="professorEmail"
+          type="email"
+          isInvalid={Boolean(errors.professorEmail)}
+          {...register("professorEmail", {
+            required: "Professor Email is required.",
+            pattern: {
+              value: emailRegex,
+              message: "Professor Email must be a valid email address.",
+            },
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.professorEmail?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="explanation">Explanation</Form.Label>
+        <Form.Control
+          data-testid={`${testIdPrefix}-explanation`}
+          id="explanation"
+          as="textarea"
+          rows={3}
+          isInvalid={Boolean(errors.explanation)}
+          {...register("explanation", {
+            required: "Explanation is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.explanation?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="dateRequested">Date Requested</Form.Label>
+        <Form.Control
+          data-testid={`${testIdPrefix}-dateRequested`}
+          id="dateRequested"
+          type="datetime-local"
+          isInvalid={Boolean(errors.dateRequested)}
+          {...register("dateRequested", {
+            required: "Date Requested is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.dateRequested?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="dateNeeded">Date Needed</Form.Label>
+        <Form.Control
+          data-testid={`${testIdPrefix}-dateNeeded`}
+          id="dateNeeded"
+          type="datetime-local"
+          isInvalid={Boolean(errors.dateNeeded)}
+          {...register("dateNeeded", {
+            required: "Date Needed is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.dateNeeded?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="done">Done</Form.Label>
+        <Form.Check
+          data-testid={`${testIdPrefix}-done`}
+          id="done"
+          type="checkbox"
+          {...register("done")}
+        />
+      </Form.Group>
+
+      <Button type="submit" data-testid={`${testIdPrefix}-submit`}>
+        {buttonLabel}
+      </Button>
+      <Button
+        variant="Secondary"
+        onClick={() => navigate(-1)}
+        data-testid={`${testIdPrefix}-cancel`}
+      >
+        Cancel
+      </Button>
+    </Form>
+  );
+}
+
+export default RecommendationRequestForm;

--- a/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.jsx
+++ b/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.jsx
@@ -1,0 +1,83 @@
+import React from "react";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+
+import { useBackendMutation } from "main/utils/useBackend";
+import {
+  cellToAxiosParamsDelete,
+  onDeleteSuccess,
+} from "main/utils/recommendationRequestUtils";
+import { useNavigate } from "react-router";
+import { hasRole } from "main/utils/useCurrentUser";
+
+export default function RecommendationRequestTable({
+  recommendationRequests,
+  currentUser,
+  testIdPrefix = "RecommendationRequestTable",
+}) {
+  const navigate = useNavigate();
+
+  const editCallback = (cell) => {
+    navigate(`/recommendationrequest/edit/${cell.row.original.id}`);
+  };
+
+  // Stryker disable all : hard to test for query caching
+  const deleteMutation = useBackendMutation(
+    cellToAxiosParamsDelete,
+    { onSuccess: onDeleteSuccess },
+    ["/api/recommendationrequests/all"],
+  );
+  // Stryker restore all
+
+  // Stryker disable next-line all : TODO try to make a good test for this
+  const deleteCallback = async (cell) => {
+    deleteMutation.mutate(cell);
+  };
+
+  const columns = [
+    {
+      header: "id",
+      accessorKey: "id",
+    },
+    {
+      header: "Requester Email",
+      accessorKey: "requesterEmail",
+    },
+    {
+      header: "Professor Email",
+      accessorKey: "professorEmail",
+    },
+    {
+      header: "Explanation",
+      accessorKey: "explanation",
+    },
+    {
+      header: "Date Requested",
+      accessorKey: "dateRequested",
+    },
+    {
+      header: "Date Needed",
+      accessorKey: "dateNeeded",
+    },
+    {
+      header: "Done",
+      accessorKey: "done",
+      // Stryker disable next-line all
+      cell: ({ cell }) => (cell.getValue() ? "true" : "false"),
+    },
+  ];
+
+  if (hasRole(currentUser, "ROLE_ADMIN")) {
+    columns.push(ButtonColumn("Edit", "primary", editCallback, testIdPrefix));
+    columns.push(
+      ButtonColumn("Delete", "danger", deleteCallback, testIdPrefix),
+    );
+  }
+
+  return (
+    <OurTable
+      data={recommendationRequests}
+      columns={columns}
+      testid={testIdPrefix}
+    />
+  );
+}

--- a/frontend/src/main/pages/RecommendationRequest/RecommendationRequestCreatePage.jsx
+++ b/frontend/src/main/pages/RecommendationRequest/RecommendationRequestCreatePage.jsx
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function RecommendationRequestCreatePage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Create page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/RecommendationRequest/RecommendationRequestEditPage.jsx
+++ b/frontend/src/main/pages/RecommendationRequest/RecommendationRequestEditPage.jsx
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function RecommendationRequestEditPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Edit page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/RecommendationRequest/RecommendationRequestIndexPage.jsx
+++ b/frontend/src/main/pages/RecommendationRequest/RecommendationRequestIndexPage.jsx
@@ -1,0 +1,18 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function RecommendationRequestIndexPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Index page not yet implemented</h1>
+        <p>
+          <a href="/recommendationrequest/create">Create</a>
+        </p>
+        <p>
+          <a href="/recommendationrequest/edit/1">Edit</a>
+        </p>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/utils/recommendationRequestUtils.js
+++ b/frontend/src/main/utils/recommendationRequestUtils.js
@@ -1,0 +1,16 @@
+import { toast } from "react-toastify";
+
+export function onDeleteSuccess(message) {
+  console.log(message);
+  toast(message);
+}
+
+export function cellToAxiosParamsDelete(cell) {
+  return {
+    url: "/api/recommendationrequests",
+    method: "DELETE",
+    params: {
+      id: cell.row.original.id,
+    },
+  };
+}

--- a/frontend/src/stories/components/RecommendationRequest/RecommendationRequestForm.stories.jsx
+++ b/frontend/src/stories/components/RecommendationRequest/RecommendationRequestForm.stories.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import RecommendationRequestForm from "main/components/RecommendationRequest/RecommendationRequestForm";
+import { recommendationRequestFixtures } from "fixtures/recommendationRequestFixtures";
+
+export default {
+  title: "components/RecommendationRequest/RecommendationRequestForm",
+  component: RecommendationRequestForm,
+};
+
+const Template = (args) => {
+  return <RecommendationRequestForm {...args} />;
+};
+
+export const Create = Template.bind({});
+
+Create.args = {
+  buttonLabel: "Create",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};
+
+export const Update = Template.bind({});
+
+Update.args = {
+  initialContents: recommendationRequestFixtures.oneRecommendationRequest,
+  buttonLabel: "Update",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};

--- a/frontend/src/stories/components/RecommendationRequest/RecommendationRequestTable.stories.jsx
+++ b/frontend/src/stories/components/RecommendationRequest/RecommendationRequestTable.stories.jsx
@@ -1,0 +1,47 @@
+import React from "react";
+import RecommendationRequestTable from "main/components/RecommendationRequest/RecommendationRequestTable";
+import { recommendationRequestFixtures } from "fixtures/recommendationRequestFixtures";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import { http, HttpResponse } from "msw";
+
+export default {
+  title: "components/RecommendationRequest/RecommendationRequestTable",
+  component: RecommendationRequestTable,
+};
+
+const Template = (args) => {
+  return <RecommendationRequestTable {...args} />;
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+  recommendationRequests: [],
+  currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.args = {
+  recommendationRequests:
+    recommendationRequestFixtures.threeRecommendationRequests,
+  currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+ThreeItemsAdminUser.args = {
+  recommendationRequests:
+    recommendationRequestFixtures.threeRecommendationRequests,
+  currentUser: currentUserFixtures.adminUser,
+};
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.delete("/api/recommendationrequests", () => {
+      return HttpResponse.json(
+        { message: "RecommendationRequest deleted successfully" },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/tests/components/Nav/AppNavbar.test.jsx
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.jsx
@@ -265,7 +265,31 @@ describe("AppNavbar tests", () => {
     expect(link.getAttribute("href")).toBe("/helprequests");
   });
 
-  test("Restaurants, Articles, UCSB Dates, MenuItemReview, and Help Requests links do NOT show when not logged in", async () => {
+  test("renders the RecommendationRequest link correctly", async () => {
+    const currentUser = currentUserFixtures.userOnly;
+    const systemInfo = systemInfoFixtures.showingBoth;
+
+    const doLogin = vi.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AppNavbar
+            currentUser={currentUser}
+            systemInfo={systemInfo}
+            doLogin={doLogin}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("RecommendationRequest");
+    const link = screen.getByText("RecommendationRequest");
+    expect(link).toBeInTheDocument();
+    expect(link.getAttribute("href")).toBe("/recommendationrequest");
+  });
+
+  test("Restaurants, Articles, UCSB Dates, MenuItemReview, Help Requests, and RecommendationRequest links do NOT show when not logged in", async () => {
     const currentUser = null;
     const systemInfo = systemInfoFixtures.showingBoth;
     const doLogin = vi.fn();
@@ -287,6 +311,7 @@ describe("AppNavbar tests", () => {
     expect(screen.queryByText("UCSB Dates")).not.toBeInTheDocument();
     expect(screen.queryByText("MenuItemReview")).not.toBeInTheDocument();
     expect(screen.queryByText("Help Requests")).not.toBeInTheDocument();
+    expect(screen.queryByText("RecommendationRequest")).not.toBeInTheDocument();
   });
 
   test("when oauthlogin undefined, default value is used", async () => {

--- a/frontend/src/tests/components/RecommendationRequest/RecommendationRequestForm.test.jsx
+++ b/frontend/src/tests/components/RecommendationRequest/RecommendationRequestForm.test.jsx
@@ -1,0 +1,152 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router";
+
+import RecommendationRequestForm from "main/components/RecommendationRequest/RecommendationRequestForm";
+import { recommendationRequestFixtures } from "fixtures/recommendationRequestFixtures";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const mockedNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const originalModule = await vi.importActual("react-router");
+  return {
+    ...originalModule,
+    useNavigate: () => mockedNavigate,
+  };
+});
+
+describe("RecommendationRequestForm tests", () => {
+  const queryClient = new QueryClient();
+
+  const expectedHeaders = [
+    "Requester Email",
+    "Professor Email",
+    "Explanation",
+    "Date Requested",
+    "Date Needed",
+    "Done",
+  ];
+  const testId = "RecommendationRequestForm";
+
+  test("renders correctly with no initialContents", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <RecommendationRequestForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId(`${testId}-id`)).not.toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-requesterEmail`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-professorEmail`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-explanation`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-dateRequested`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-dateNeeded`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-done`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-submit`)).toBeInTheDocument();
+  });
+
+  test("renders correctly when passing in initialContents", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <RecommendationRequestForm
+            initialContents={
+              recommendationRequestFixtures.oneRecommendationRequest
+            }
+          />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(await screen.findByTestId(`${testId}-id`)).toBeInTheDocument();
+    expect(screen.getByText("Id")).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-id`)).toHaveValue("1");
+    expect(screen.getByTestId(`${testId}-requesterEmail`)).toHaveValue(
+      "student@ucsb.edu",
+    );
+    expect(screen.getByTestId(`${testId}-professorEmail`)).toHaveValue(
+      "professor@ucsb.edu",
+    );
+    expect(screen.getByTestId(`${testId}-explanation`)).toHaveValue(
+      "Requesting a recommendation for graduate school.",
+    );
+    expect(screen.getByTestId(`${testId}-dateRequested`)).toHaveValue(
+      "2026-04-15T10:30",
+    );
+    expect(screen.getByTestId(`${testId}-dateNeeded`)).toHaveValue(
+      "2026-05-01T17:00",
+    );
+    expect(screen.getByTestId(`${testId}-done`)).not.toBeChecked();
+  });
+
+  test("that navigate(-1) is called when Cancel is clicked", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <RecommendationRequestForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+    expect(await screen.findByTestId(`${testId}-cancel`)).toBeInTheDocument();
+    const cancelButton = screen.getByTestId(`${testId}-cancel`);
+
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+  });
+
+  test("that the correct validations are performed", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <RecommendationRequestForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+    const submitButton = screen.getByTestId(`${testId}-submit`);
+    fireEvent.click(submitButton);
+
+    expect(
+      await screen.findByText(/Requester Email is required/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Professor Email is required/)).toBeInTheDocument();
+    expect(screen.getByText(/Explanation is required/)).toBeInTheDocument();
+    expect(screen.getByText(/Date Requested is required/)).toBeInTheDocument();
+    expect(screen.getByText(/Date Needed is required/)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId(`${testId}-requesterEmail`), {
+      target: { value: "not-an-email" },
+    });
+    fireEvent.change(screen.getByTestId(`${testId}-professorEmail`), {
+      target: { value: "also-not-an-email" },
+    });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Requester Email must be a valid email address/),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/Professor Email must be a valid email address/),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/components/RecommendationRequest/RecommendationRequestTable.test.jsx
+++ b/frontend/src/tests/components/RecommendationRequest/RecommendationRequestTable.test.jsx
@@ -1,0 +1,262 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import { recommendationRequestFixtures } from "fixtures/recommendationRequestFixtures";
+import RecommendationRequestTable from "main/components/RecommendationRequest/RecommendationRequestTable";
+import {
+  cellToAxiosParamsDelete,
+  onDeleteSuccess,
+} from "main/utils/recommendationRequestUtils";
+
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
+const mockedNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const originalModule = await vi.importActual("react-router");
+  return {
+    ...originalModule,
+    useNavigate: () => mockedNavigate,
+  };
+});
+
+describe("RecommendationRequestTable tests", () => {
+  const queryClient = new QueryClient();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const expectedHeaders = [
+    "id",
+    "Requester Email",
+    "Professor Email",
+    "Explanation",
+    "Date Requested",
+    "Date Needed",
+    "Done",
+  ];
+  const expectedFields = [
+    "id",
+    "requesterEmail",
+    "professorEmail",
+    "explanation",
+    "dateRequested",
+    "dateNeeded",
+    "done",
+  ];
+  const testId = "RecommendationRequestTable";
+
+  test("renders empty table correctly", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RecommendationRequestTable
+            recommendationRequests={[]}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const fieldElement = screen.queryByTestId(
+        `${testId}-cell-row-0-col-${field}`,
+      );
+      expect(fieldElement).not.toBeInTheDocument();
+    });
+  });
+
+  test("Has the expected column headers, content and buttons for admin user", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RecommendationRequestTable
+            recommendationRequests={
+              recommendationRequestFixtures.threeRecommendationRequests
+            }
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const cell = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(cell).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-requesterEmail`),
+    ).toHaveTextContent("student1@ucsb.edu");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-professorEmail`),
+    ).toHaveTextContent("professor1@ucsb.edu");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-done`),
+    ).toHaveTextContent("false");
+
+    const editButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
+    );
+    expect(editButton).toBeInTheDocument();
+    expect(editButton).toHaveClass("btn-primary");
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
+  });
+
+  test("Has the expected column headers, content for ordinary user", () => {
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RecommendationRequestTable
+            recommendationRequests={
+              recommendationRequestFixtures.threeRecommendationRequests
+            }
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const cell = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(cell).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-explanation`),
+    ).toHaveTextContent("Requesting a recommendation for a summer internship.");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-done`),
+    ).toHaveTextContent("true");
+
+    expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+    expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+  });
+
+  test("Edit button navigates to the edit page", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RecommendationRequestTable
+            recommendationRequests={
+              recommendationRequestFixtures.threeRecommendationRequests
+            }
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      await screen.findByTestId(`${testId}-cell-row-0-col-id`),
+    ).toHaveTextContent("1");
+
+    const editButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
+    );
+    fireEvent.click(editButton);
+
+    await waitFor(() =>
+      expect(mockedNavigate).toHaveBeenCalledWith(
+        "/recommendationrequest/edit/1",
+      ),
+    );
+  });
+
+  test("cellToAxiosParamsDelete returns the correct params", () => {
+    const cell = { row: { original: { id: 17 } } };
+    expect(cellToAxiosParamsDelete(cell)).toEqual({
+      url: "/api/recommendationrequests",
+      method: "DELETE",
+      params: { id: 17 },
+    });
+  });
+
+  test("onDeleteSuccess logs and toasts the message", () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    onDeleteSuccess("RecommendationRequest deleted");
+    expect(consoleSpy).toHaveBeenCalledWith("RecommendationRequest deleted");
+    expect(mockToast).toHaveBeenCalledWith("RecommendationRequest deleted");
+    consoleSpy.mockRestore();
+  });
+
+  test("Delete button calls delete callback", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    const axiosMock = new AxiosMockAdapter(axios);
+    axiosMock
+      .onDelete("/api/recommendationrequests")
+      .reply(200, { message: "RecommendationRequest deleted" });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RecommendationRequestTable
+            recommendationRequests={
+              recommendationRequestFixtures.threeRecommendationRequests
+            }
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      await screen.findByTestId(`${testId}-cell-row-0-col-id`),
+    ).toHaveTextContent("1");
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => expect(axiosMock.history.delete.length).toBe(1));
+    expect(axiosMock.history.delete[0].params).toEqual({ id: 1 });
+    axiosMock.restore();
+  });
+});

--- a/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestCreatePage.test.jsx
+++ b/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestCreatePage.test.jsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import RecommendationRequestCreatePage from "main/pages/RecommendationRequest/RecommendationRequestCreatePage";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { expect } from "vitest";
+
+describe("RecommendationRequestCreatePage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    setupUserOnly();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RecommendationRequestCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Create page not yet implemented");
+    expect(
+      screen.getByText("Create page not yet implemented"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestEditPage.test.jsx
+++ b/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestEditPage.test.jsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import RecommendationRequestEditPage from "main/pages/RecommendationRequest/RecommendationRequestEditPage";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { expect } from "vitest";
+
+describe("RecommendationRequestEditPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    setupUserOnly();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RecommendationRequestEditPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Edit page not yet implemented");
+    expect(
+      screen.getByText("Edit page not yet implemented"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestIndexPage.test.jsx
+++ b/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestIndexPage.test.jsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import RecommendationRequestIndexPage from "main/pages/RecommendationRequest/RecommendationRequestIndexPage";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("RecommendationRequestIndexPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    setupUserOnly();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RecommendationRequestIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Index page not yet implemented");
+
+    expect(
+      screen.getByText("Index page not yet implemented"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Create")).toBeInTheDocument();
+    expect(screen.getByText("Create")).toHaveAttribute(
+      "href",
+      "/recommendationrequest/create",
+    );
+    expect(screen.getByText("Edit")).toBeInTheDocument();
+    expect(screen.getByText("Edit")).toHaveAttribute(
+      "href",
+      "/recommendationrequest/edit/1",
+    );
+  });
+});


### PR DESCRIPTION
Merge after the RecommendationRequest form PR.

This PR adds a RecommendationRequest table so users can view recommendation request records in the frontend.

Closes #23

## Summary
- Adds RecommendationRequestTable with columns for requester/professor email, explanation, requested/needed dates, and done status.
- Adds admin-only edit and delete buttons.
- Adds delete utility functions for the RecommendationRequest API.
- Adds table tests and Storybook stories for empty, ordinary user, and admin user states.

## Testing
- Ran npm test from frontend with Node 22.22.2
- Verified 47 test files and 171 tests pass with 100% coverage

## Storybook
- Story: components/RecommendationRequest/RecommendationRequestTable
- Stories: Empty, ThreeItemsOrdinaryUser, ThreeItemsAdminUser