### PR TITLE
rl - add javascript fixtures for organizations table

### DIFF
--- a/frontend/src/fixtures/ucsOrganizationsFixtures.js
+++ b/frontend/src/fixtures/ucsOrganizationsFixtures.js
@@ -1,29 +1,29 @@
 const ucsbOrganizationsFixtures = {
   oneOrganization: {
-      "orgCode": "ZPR",
-      "orgTranslationShort": "ZETA PHI RHO",
-      "orgTranslation": "ZETA PHI RHO",
-      "inactive": false
+    orgCode: "ZPR",
+    orgTranslationShort: "ZETA PHI RHO",
+    orgTranslation: "ZETA PHI RHO",
+    inactive: false,
   },
   threeOrganizations: [
     {
-      "orgCode": "ZPR",
-      "orgTranslationShort": "ZETA PHI RHO",
-      "orgTranslation": "ZETA PHI RHO",
-      "inactive": false
+      orgCode: "ZPR",
+      orgTranslationShort: "ZETA PHI RHO",
+      orgTranslation: "ZETA PHI RHO",
+      inactive: false,
     },
     {
-      "orgCode": "SKY",
-      "orgTranslationShort": "SKYDIVING CLUB",
-      "orgTranslation": "SKYDIVING CLUB AT UCSB",
-      "inactive": false
+      orgCode: "SKY",
+      orgTranslationShort: "SKYDIVING CLUB",
+      orgTranslation: "SKYDIVING CLUB AT UCSB",
+      inactive: false,
     },
     {
-      "orgCode": "OSLI",
-      "orgTranslationShort": "STUDENT LIFE",
-      "orgTranslation": "OFFICE OF STUDENT LIFE",
-      "inactive": false
-    }
+      orgCode: "OSLI",
+      orgTranslationShort: "STUDENT LIFE",
+      orgTranslation: "OFFICE OF STUDENT LIFE",
+      inactive: false,
+    },
   ],
 };
 

--- a/frontend/src/fixtures/ucsOrganizationsFixtures.js
+++ b/frontend/src/fixtures/ucsOrganizationsFixtures.js
@@ -1,0 +1,30 @@
+const ucsbOrganizationsFixtures = {
+  oneOrganization: {
+      "orgCode": "ZPR",
+      "orgTranslationShort": "ZETA PHI RHO",
+      "orgTranslation": "ZETA PHI RHO",
+      "inactive": false
+  },
+  threeOrganizations: [
+    {
+      "orgCode": "ZPR",
+      "orgTranslationShort": "ZETA PHI RHO",
+      "orgTranslation": "ZETA PHI RHO",
+      "inactive": false
+    },
+    {
+      "orgCode": "SKY",
+      "orgTranslationShort": "SKYDIVING CLUB",
+      "orgTranslation": "SKYDIVING CLUB AT UCSB",
+      "inactive": false
+    },
+    {
+      "orgCode": "OSLI",
+      "orgTranslationShort": "STUDENT LIFE",
+      "orgTranslation": "OFFICE OF STUDENT LIFE",
+      "inactive": false
+    }
+  ],
+};
+
+export { ucsbOrganizationsFixtures };


### PR DESCRIPTION
Closes #12 

Merge after PR #101 

In this PR, we add fixtures for the organizations  table in the frontend code.

These will be used for tests and for storybook entries later on. 

*5/2/2026 RL - rebased so ready for merge