### PR TITLE
Rl create organizations page

### DIFF
--- a/frontend/src/main/pages/UCSBOrganizations/UCSBOrganizationsCreatePage.jsx
+++ b/frontend/src/main/pages/UCSBOrganizations/UCSBOrganizationsCreatePage.jsx
@@ -1,11 +1,49 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import UCSBOrganizationForm from "main/components/UCSBOrganizations/UCSBOrganizationForm";
+import { Navigate } from "react-router";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function UCSBOrganizationsCreatePage() {
-  // Stryker disable all : placeholder for future implementation
+export default function UCSBOrganizationsCreatePage({ storybook = false }) {
+  const objectToAxiosParams = (ucsborganization) => ({
+    url: "/api/ucsborganizations/post",
+    method: "POST",
+    params: {
+      orgCode: ucsborganization.orgCode,
+      orgTranslationShort: ucsborganization.orgTranslationShort,
+      orgTranslation: ucsborganization.orgTranslation,
+      inactive: ucsborganization.inactive,
+    },
+  });
+
+  const onSuccess = (ucsborganization) => {
+    toast(
+      `New organization Created - orgCode: ${ucsborganization.orgCode} orgTranslation: ${ucsborganization.orgTranslation}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    ["/api/ucsborganizations/all"], // mutation makes this key stale so that pages relying on it reload
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/ucsborganizations" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create New UCSBOrganization</h1>
+        <UCSBOrganizationForm submitAction={onSubmit} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/UCSBOrganizations/UCSBOrganizationsCreatePage.jsx
+++ b/frontend/src/main/pages/UCSBOrganizations/UCSBOrganizationsCreatePage.jsx
@@ -18,7 +18,7 @@ export default function UCSBOrganizationsCreatePage({ storybook = false }) {
 
   const onSuccess = (ucsborganization) => {
     toast(
-      `New organization Created - orgCode: ${ucsborganization.orgCode} orgTranslation: ${ucsborganization.orgTranslation}`,
+      `New ucsborganization Created - orgCode: ${ucsborganization.orgCode} orgTranslation: ${ucsborganization.orgTranslation}`,
     );
   };
 

--- a/frontend/src/stories/pages/UCSBOrganizations/UCSBOrganizationsCreatePage.stories.jsx
+++ b/frontend/src/stories/pages/UCSBOrganizations/UCSBOrganizationsCreatePage.stories.jsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import UCSBOrganizationsCreatePage from "main/pages/UCSBOrganizations/UCSBOrganizationsCreatePage";
+
+import { ucsbOrganizationsFixtures } from "fixtures/ucsbOrganizationsFixtures";
+
+export default {
+  title: "pages/UCSBOrganizations/UCSBOrganizationsCreatePage",
+  component: UCSBOrganizationsCreatePage,
+};
+
+const Template = () => <UCSBOrganizationsCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.post("/api/ucsborganizations/post", () => {
+      return HttpResponse.json(ucsbOrganizationsFixtures.oneOrganization, {
+        status: 200,
+      });
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/UCSBOrganizations/UCSBOrganizationsCreatePage.test.jsx
+++ b/frontend/src/tests/pages/UCSBOrganizations/UCSBOrganizationsCreatePage.test.jsx
@@ -1,18 +1,40 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import UCSBOrganizationsCreatePage from "main/pages/UCSBOrganizations/UCSBOrganizationsCreatePage";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { expect } from "vitest";
+
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
+const mockNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    Navigate: vi.fn((x) => {
+      mockNavigate(x);
+      return null;
+    }),
+  };
+});
 
 describe("UCSBOrganizationsCreatePage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
 
-  const setupUserOnly = () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
     axiosMock.reset();
     axiosMock.resetHistory();
     axiosMock
@@ -21,15 +43,10 @@ describe("UCSBOrganizationsCreatePage tests", () => {
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
-  };
+  });
 
   const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
-
-    setupUserOnly();
-
-    // act
+  test("renders without crashing", async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -38,11 +55,76 @@ describe("UCSBOrganizationsCreatePage tests", () => {
       </QueryClientProvider>,
     );
 
-    // assert
+    await waitFor(() => {
+      expect(screen.getByLabelText("Org Code")).toBeInTheDocument();
+    });
+  });
 
-    await screen.findByText("Create page not yet implemented");
-    expect(
-      screen.getByText("Create page not yet implemented"),
-    ).toBeInTheDocument();
+  test("on submit, makes request to backend, and redirects to /ucsborganizations", async () => {
+    const queryClient = new QueryClient();
+    const ucsborganization = {
+      orgCode: "ZPR",
+      orgTranslationShort: "ZETA PHI RHO",
+      orgTranslation: "ZETA PHI RHO",
+      inactive: false,
+    };
+
+    axiosMock
+      .onPost("/api/ucsborganizations/post")
+      .reply(202, ucsborganization);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationsCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Org Code")).toBeInTheDocument();
+    });
+
+    const orgCodeInput = screen.getByLabelText("Org Code");
+    expect(orgCodeInput).toBeInTheDocument();
+
+    const orgTranslationShortInput = screen.getByLabelText(
+      "Org Translation Short",
+    );
+    expect(orgTranslationShortInput).toBeInTheDocument();
+
+    const orgTranslationInput = screen.getByLabelText("Org Translation");
+    expect(orgTranslationInput).toBeInTheDocument();
+
+    const inactiveInput = screen.getByLabelText("Inactive");
+    expect(inactiveInput).toBeInTheDocument();
+
+    const createButton = screen.getByText("Create");
+    expect(createButton).toBeInTheDocument();
+
+    fireEvent.change(orgCodeInput, { target: { value: "ZPR" } });
+    fireEvent.change(orgTranslationShortInput, {
+      target: { value: "ZETA PHI RHO" },
+    });
+    fireEvent.change(orgTranslationInput, {
+      target: { value: "ZETA PHI RHO" },
+    });
+    fireEvent.change(inactiveInput, { target: { value: false } });
+    fireEvent.click(createButton);
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].params).toEqual({
+      orgCode: "ZPR",
+      orgTranslationShort: "ZETA PHI RHO",
+      orgTranslation: "ZETA PHI RHO",
+      inactive: false,
+    });
+
+    // assert - check that the toast was called with the expected message
+    expect(mockToast).toBeCalledWith(
+      "New ucsborganization Created - orgCode: ZPR orgTranslation: ZETA PHI RHO",
+    );
+    expect(mockNavigate).toBeCalledWith({ to: "/ucsborganizations" });
   });
 });


### PR DESCRIPTION
Closes #16 

Merge after #106 

In this PR, we replaced the placeholder Create Organization Page with a working create page for organizations.

Storybook: https://69f15715faec6e353d8ea289-zjjhagnqxu.chromatic.com/?path=/story/pages-ucsborganizations-ucsborganizationscreatepage--default

To test:
1. Login to this dokku instance: https://team02-dev-ryanlongacre.dokku-09.cs.ucsb.edu/
2. Navigate to create page for organizations
3. Fill out the fields
4. Click Create
5. Check the /api/organizations/all endpoint to see the new record in the database

