### PR TITLE
cb articles index page

### DIFF
--- a/frontend/src/main/pages/Articles/ArticlesCreatePage.jsx
+++ b/frontend/src/main/pages/Articles/ArticlesCreatePage.jsx
@@ -1,11 +1,48 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import ArticlesForm from "main/components/Articles/ArticlesForm";
+import { Navigate } from "react-router";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function ArticlesCreatePage() {
-  // Stryker disable all : placeholder for future implementation
+export default function ArticlesCreatePage({ storybook = false }) {
+  const objectToAxiosParams = (article) => ({
+    url: "/api/Articles/post",
+    method: "POST",
+    params: {
+      title: article.title,
+      url: article.url,
+      explanation: article.explanation,
+      email: article.email,
+      dateAdded: article.dateAdded,
+    },
+  });
+
+  const onSuccess = (article) => {
+    toast(`New article Created - id: ${article.id} title: ${article.title}`);
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    ["/api/Articles/all"],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/articles" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create New Article</h1>
+        <ArticlesForm submitAction={onSubmit} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/Articles/ArticlesIndexPage.jsx
+++ b/frontend/src/main/pages/Articles/ArticlesIndexPage.jsx
@@ -1,17 +1,46 @@
+import React from "react";
+import { useBackend } from "main/utils/useBackend";
+
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import ArticlesTable from "main/components/Articles/ArticlesTable";
+import { useCurrentUser, hasRole } from "main/utils/useCurrentUser";
+import { Button } from "react-bootstrap";
 
 export default function ArticlesIndexPage() {
-  // Stryker disable all : placeholder for future implementation
+  const currentUser = useCurrentUser();
+
+  const {
+    data: articles,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/Articles/all"],
+    { method: "GET", url: "/api/Articles/all" },
+    // Stryker disable next-line all : don't test default value of empty list
+    [],
+  );
+
+  const createButton = () => {
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+      return (
+        <Button
+          variant="primary"
+          href="/articles/create"
+          style={{ float: "right" }}
+        >
+          Create Article
+        </Button>
+      );
+    }
+  };
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Index page not yet implemented</h1>
-        <p>
-          <a href="/articles/create">Create</a>
-        </p>
-        <p>
-          <a href="/articles/edit/1">Edit</a>
-        </p>
+        {createButton()}
+        <h1>Articles</h1>
+        <ArticlesTable articles={articles} currentUser={currentUser} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/Articles/ArticlesCreatePage.stories.jsx
+++ b/frontend/src/stories/pages/Articles/ArticlesCreatePage.stories.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import ArticlesCreatePage from "main/pages/Articles/ArticlesCreatePage";
+
+export default {
+  title: "pages/Articles/ArticlesCreatePage",
+  component: ArticlesCreatePage,
+};
+
+const Template = () => <ArticlesCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.post("/api/Articles/post", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/stories/pages/Articles/ArticlesIndexPage.stories.jsx
+++ b/frontend/src/stories/pages/Articles/ArticlesIndexPage.stories.jsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { articlesFixtures } from "fixtures/articlesFixtures";
+import { http, HttpResponse } from "msw";
+
+import ArticlesIndexPage from "main/pages/Articles/ArticlesIndexPage";
+
+export default {
+  title: "pages/Articles/ArticlesIndexPage",
+  component: ArticlesIndexPage,
+};
+
+const Template = () => <ArticlesIndexPage storybook={true} />;
+
+export const Empty = Template.bind({});
+Empty.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/Articles/all", () => {
+      return HttpResponse.json([], { status: 200 });
+    }),
+  ],
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+ThreeItemsOrdinaryUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/Articles/all", () => {
+      return HttpResponse.json(articlesFixtures.threeArticles);
+    }),
+  ],
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.adminUser);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/Articles/all", () => {
+      return HttpResponse.json(articlesFixtures.threeArticles);
+    }),
+    http.delete("/api/Articles", () => {
+      return HttpResponse.json(
+        { message: "Articles deleted successfully" },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/Articles/ArticlesCreatePage.test.jsx
+++ b/frontend/src/tests/pages/Articles/ArticlesCreatePage.test.jsx
@@ -1,17 +1,40 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import ArticlesCreatePage from "main/pages/Articles/ArticlesCreatePage";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
+const mockNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    Navigate: vi.fn((x) => {
+      mockNavigate(x);
+      return null;
+    }),
+  };
+});
 
 describe("ArticlesCreatePage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
 
-  const setupUserOnly = () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
     axiosMock.reset();
     axiosMock.resetHistory();
     axiosMock
@@ -20,13 +43,11 @@ describe("ArticlesCreatePage tests", () => {
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
-  };
+  });
 
   const queryClient = new QueryClient();
 
-  test("Renders expected content", async () => {
-    setupUserOnly();
-
+  test("renders without crashing", async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -35,9 +56,83 @@ describe("ArticlesCreatePage tests", () => {
       </QueryClientProvider>,
     );
 
-    await screen.findByText("Create page not yet implemented");
-    expect(
-      screen.getByText("Create page not yet implemented"),
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByLabelText("Title")).toBeInTheDocument();
+    });
+  });
+
+  test("on submit, makes request to backend, and redirects to /articles", async () => {
+    const localQueryClient = new QueryClient();
+    const article = {
+      id: 3,
+      title: "Ocean Cleanup Milestone",
+      url: "https://example.org/ocean-cleanup",
+      explanation: "Reports on a major milestone for ocean cleanup efforts.",
+      email: "author@example.org",
+      dateAdded: "2026-04-30T14:15",
+    };
+
+    axiosMock.onPost("/api/Articles/post").reply(202, article);
+
+    render(
+      <QueryClientProvider client={localQueryClient}>
+        <MemoryRouter>
+          <ArticlesCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Title")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText("Title"), {
+      target: { value: article.title },
+    });
+    fireEvent.change(screen.getByLabelText("URL"), {
+      target: { value: article.url },
+    });
+    fireEvent.change(screen.getByLabelText("Explanation"), {
+      target: { value: article.explanation },
+    });
+    fireEvent.change(screen.getByLabelText("Email"), {
+      target: { value: article.email },
+    });
+    fireEvent.change(screen.getByLabelText("Date Added"), {
+      target: { value: article.dateAdded },
+    });
+    fireEvent.click(screen.getByText("Create"));
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].params).toEqual({
+      title: "Ocean Cleanup Milestone",
+      url: "https://example.org/ocean-cleanup",
+      explanation: "Reports on a major milestone for ocean cleanup efforts.",
+      email: "author@example.org",
+      dateAdded: "2026-04-30T14:15",
+    });
+
+    expect(mockToast).toBeCalledWith(
+      "New article Created - id: 3 title: Ocean Cleanup Milestone",
+    );
+    expect(mockNavigate).toBeCalledWith({ to: "/articles" });
+  });
+
+  test("invalid data does not submit", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticlesCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByLabelText("Title");
+    fireEvent.click(screen.getByText("Create"));
+
+    await screen.findByText(/Title is required/);
+    expect(axiosMock.history.post.length).toBe(0);
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/tests/pages/Articles/ArticlesIndexPage.test.jsx
+++ b/frontend/src/tests/pages/Articles/ArticlesIndexPage.test.jsx
@@ -1,15 +1,28 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import ArticlesIndexPage from "main/pages/Articles/ArticlesIndexPage";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
+import mockConsole from "tests/testutils/mockConsole";
+import { articlesFixtures } from "fixtures/articlesFixtures";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
 describe("ArticlesIndexPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
+
+  const testId = "ArticlesTable";
 
   const setupUserOnly = () => {
     axiosMock.reset();
@@ -22,10 +35,22 @@ describe("ArticlesIndexPage tests", () => {
       .reply(200, systemInfoFixtures.showingNeither);
   };
 
+  const setupAdminUser = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.adminUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
   const queryClient = new QueryClient();
 
-  test("Renders expected content", async () => {
-    setupUserOnly();
+  test("Renders with Create Button for admin user", async () => {
+    setupAdminUser();
+    axiosMock.onGet("/api/Articles/all").reply(200, []);
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -35,18 +60,126 @@ describe("ArticlesIndexPage tests", () => {
       </QueryClientProvider>,
     );
 
-    await screen.findByText("Index page not yet implemented");
+    await waitFor(() => {
+      expect(screen.getByText(/Create Article/)).toBeInTheDocument();
+    });
+    const button = screen.getByText(/Create Article/);
+    expect(button).toHaveAttribute("href", "/articles/create");
+    expect(button).toHaveAttribute("style", "float: right;");
+  });
+
+  test("renders three articles correctly for regular user", async () => {
+    setupUserOnly();
+    axiosMock
+      .onGet("/api/Articles/all")
+      .reply(200, articlesFixtures.threeArticles);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticlesIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toHaveTextContent("1");
+    });
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent(
+      "3",
+    );
+
+    const createArticleButton = screen.queryByText("Create Article");
+    expect(createArticleButton).not.toBeInTheDocument();
 
     expect(
-      screen.getByText("Index page not yet implemented"),
+      screen.getByText("AI Breakthrough in Climate Modeling"),
     ).toBeInTheDocument();
-    expect(screen.getByText("Create")).toBeInTheDocument();
-    expect(screen.getByText("Edit")).toBeInTheDocument();
-    expect(screen.getByText("Create").getAttribute("href")).toBe(
-      "/articles/create",
+    expect(
+      screen.getByText("https://example.org/climate-ai"),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByTestId("ArticlesTable-cell-row-0-col-Delete-button"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("ArticlesTable-cell-row-0-col-Edit-button"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("renders empty table when backend unavailable, user only", async () => {
+    setupUserOnly();
+    axiosMock.onGet("/api/Articles/all").timeout();
+
+    const restoreConsole = mockConsole();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticlesIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
     );
-    expect(screen.getByText("Edit").getAttribute("href")).toBe(
-      "/articles/edit/1",
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+
+    const errorMessage = console.error.mock.calls[0][0];
+    expect(errorMessage).toMatch(
+      "Error communicating with backend via GET on /api/Articles/all",
     );
+    restoreConsole();
+  });
+
+  test("what happens when you click delete, admin", async () => {
+    setupAdminUser();
+
+    axiosMock
+      .onGet("/api/Articles/all")
+      .reply(200, articlesFixtures.threeArticles);
+    axiosMock
+      .onDelete("/api/Articles")
+      .reply(200, "Articles with id 1 deleted");
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticlesIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+
+    const deleteButton = await screen.findByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(mockToast).toBeCalledWith("Articles with id 1 deleted");
+    });
+
+    await waitFor(() => {
+      expect(axiosMock.history.delete.length).toBe(1);
+    });
+    expect(axiosMock.history.delete[0].url).toBe("/api/Articles");
+    expect(axiosMock.history.delete[0].params).toEqual({ id: 1 });
   });
 });


### PR DESCRIPTION
- Replaced the placeholder Articles page with a real page that loads and displays article data.
- Added admin-only controls to create, edit, and delete articles.
- Kept regular logged-in users in read-only mode.
- Added tests for loading, permissions, and delete behavior.
- Added Storybook entries so the page can be reviewed visually in different states.

Closes #53 

https://69f15715faec6e353d8ea289-yjdslijtga.chromatic.com/?path=/story/pages-articles-articlesindexpage--three-items-ordinary-user

<img width="2334" height="533" alt="image" src="https://github.com/user-attachments/assets/88960578-5cbc-4912-8cd4-11bf4a88ae77" />
